### PR TITLE
add return value method to TraceVariable

### DIFF
--- a/models/classes/class.TraceVariable.php
+++ b/models/classes/class.TraceVariable.php
@@ -53,6 +53,16 @@ class taoResultServer_models_classes_TraceVariable extends taoResultServer_model
     {
         return $this->trace;
     }
+    
+    /**
+     * Return value.
+     * @author  Aleh Hutnikau, <hutnikau@1pt.com>
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->getTrace();
+    }
 }
 
 ?>


### PR DESCRIPTION
Needed to have `getValue()` method to be able use `TraceVariable` in result table:
https://github.com/oat-sa/extension-tao-outcomeui/blob/master/views/templates/viewResult.tpl#L53