### PR TITLE
Feature/json key value cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '2.12.1',
+    'version' => '2.13.0',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/classes/class.OutcomeVariable.php
+++ b/models/classes/class.OutcomeVariable.php
@@ -109,6 +109,20 @@ class taoResultServer_models_classes_OutcomeVariable extends taoResultServer_mod
         //null byte, binary 
         $this->value = base64_encode($value);
     }
+    
+    public static function fromArray($array)
+    {
+        $variable = new static();
+        $variable->setIdentifier($array['identifier']);
+        $variable->setCardinality($array['cardinality']);
+        $variable->setBaseType($array['baseType']);
+        $variable->setEpoch($array['epoch']);
+        $variable->setNormalMaximum($array['normalMaximum']);
+        $variable->setNormalMinimum($array['normalMinimum']);
+        $variable->value = $array['value'];
+        
+        return $variable;
+    }
 }
 
 ?>

--- a/models/classes/class.ResponseVariable.php
+++ b/models/classes/class.ResponseVariable.php
@@ -104,6 +104,19 @@ class taoResultServer_models_classes_ResponseVariable extends taoResultServer_mo
     public function setValue($value){
         $this->setCandidateResponse($value);
     }
+    
+    public static function fromArray($array)
+    {
+        $variable = new static();
+        $variable->setIdentifier($array['identifier']);
+        $variable->setCardinality($array['cardinality']);
+        $variable->setBaseType($array['baseType']);
+        $variable->setEpoch($array['epoch']);
+        $variable->candidateResponse  = $array['candidateResponse'];
+        $variable->correctResponse = $array['correctResponse'];
+        
+        return $variable;
+    }
 }
 
 ?>

--- a/models/classes/class.TraceVariable.php
+++ b/models/classes/class.TraceVariable.php
@@ -72,6 +72,18 @@ class taoResultServer_models_classes_TraceVariable extends taoResultServer_model
     {
         $this->setTrace($value);
     }
+    
+    public static function fromArray($array)
+    {
+        $variable = new static();
+        $variable->setIdentifier($array['identifier']);
+        $variable->setCardinality($array['cardinality']);
+        $variable->setBaseType($array['baseType']);
+        $variable->setEpoch($array['epoch']);
+        $variable->setTrace($array['trace']);
+        
+        return $variable;
+    }
 }
 
 ?>

--- a/models/classes/class.Variable.php
+++ b/models/classes/class.Variable.php
@@ -25,7 +25,7 @@
  * test at all. For example, items that are organized with learning resources and presented 
  * individually in a formative context.
  */
-abstract class taoResultServer_models_classes_Variable 
+abstract class taoResultServer_models_classes_Variable implements \oat\oatbox\ArrayCastable
 //implements JsonSerializable 
     {
 
@@ -161,6 +161,19 @@ abstract class taoResultServer_models_classes_Variable
      */
     public function toJson() {
         return json_encode((array)$this);
+    }
+    
+    public function __toArray()
+    {
+        $array = (array)$this;
+        $array['class'] = get_class($this);
+        
+        return $array;
+    }
+    
+    public static function fromArray($array)
+    {
+        return call_user_func([$array['class'], 'fromArray'], $array);
     }
 }
 ?>

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -51,6 +51,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('2.12.0');
         }
 
-        $this->skip('2.12.0', '2.12.1');
+        $this->skip('2.12.0', '2.13.0');
     }
 }


### PR DESCRIPTION
**DEPENDS ON https://github.com/oat-sa/generis/pull/311**

Enable "array serialization" for Menu Model in TAO Outcome, in order to be "JSON Cacheable". See dependent PR https://github.com/oat-sa/generis/pull/311 for more information about the intent.