### PR TITLE
Implement appropriate interface.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '3.2.4',
+    'version' => '3.2.5',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/classes/ResultServerService.php
+++ b/models/classes/ResultServerService.php
@@ -36,7 +36,7 @@ interface ResultServerService {
      *
      * @param string $deliveryId
      * @throws \common_exception_Error
-     * @return \taoResultServer_models_classes_ReadableResultStorage
+     * @return \taoResultServer_models_classes_ReadableResultStorage|\taoResultServer_models_classes_WritableResultStorage|oat\taoResultServer\models\classes\ResultManagement
      */
     public function getResultStorage($deliveryId);
 }

--- a/models/classes/implementation/OntologyService.php
+++ b/models/classes/implementation/OntologyService.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 namespace oat\taoResultServer\models\classes\implementation;
@@ -23,8 +23,9 @@ use taoResultServer_models_classes_ResultServerStateFull;
 use oat\generis\model\OntologyAwareTrait;
 use oat\taoResultServer\models\classes\ResultServiceTrait;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoResultServer\models\classes\ResultServerService;
 
-class OntologyService extends ConfigurableService
+class OntologyService extends ConfigurableService implements ResultServerService
 {
     
     use OntologyAwareTrait;

--- a/models/classes/implementation/OntologyService.php
+++ b/models/classes/implementation/OntologyService.php
@@ -64,7 +64,7 @@ class OntologyService extends ConfigurableService implements ResultServerService
      * 
      * @param string $deliveryId
      * @throws \common_exception_Error
-     * @return \taoResultServer_models_classes_ReadableResultStorage
+     * @return @return \taoResultServer_models_classes_ReadableResultStorage|\taoResultServer_models_classes_WritableResultStorage|oat\taoResultServer\models\classes\ResultManagement
      */
     public function getResultStorage($deliveryId)
     {

--- a/models/classes/implementation/OntologyService.php
+++ b/models/classes/implementation/OntologyService.php
@@ -64,7 +64,7 @@ class OntologyService extends ConfigurableService implements ResultServerService
      * 
      * @param string $deliveryId
      * @throws \common_exception_Error
-     * @return @return \taoResultServer_models_classes_ReadableResultStorage|\taoResultServer_models_classes_WritableResultStorage|oat\taoResultServer\models\classes\ResultManagement
+     * @return \taoResultServer_models_classes_ReadableResultStorage|\taoResultServer_models_classes_WritableResultStorage|oat\taoResultServer\models\classes\ResultManagement
      */
     public function getResultStorage($deliveryId)
     {

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -63,6 +63,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('3.2.1');
         }
 
-        $this->skip('3.2.1', '3.2.4');
+        $this->skip('3.2.1', '3.2.5');
     }
 }


### PR DESCRIPTION
It seems that to be consistent the `OntologyService` class should implement the `ResultServerService` interface. Could you please confirm @jbout ?