### PR TITLE
Tao 5706/resultstorage configuration displayed but not used

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '5.0.0',
+    'version' => '5.0.1',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/classes/AbstractResultService.php
+++ b/models/classes/AbstractResultService.php
@@ -26,6 +26,8 @@ use \taoResultServer_models_classes_WritableResultStorage as WritableResultStora
 
 abstract class AbstractResultService extends ConfigurableService implements ResultServerService
 {
+    /** @var bool $configurable Whether this ResultServerService instance is configurable */
+    protected $configurable = true;
 
     /**
      * Starts or resume a taoResultServerStateFull session for results submission
@@ -74,5 +76,10 @@ abstract class AbstractResultService extends ConfigurableService implements Resu
 
 
     abstract public function getResultStorage($deliveryId);
+
+    public function isConfigurable()
+    {
+        return $this->configurable;
+    }
 
 }

--- a/models/classes/ResultServerService.php
+++ b/models/classes/ResultServerService.php
@@ -51,4 +51,6 @@ interface ResultServerService {
      */
     public function getResultStorage($deliveryId);
 
+    public function isConfigurable();
+
 }

--- a/models/classes/implementation/OntologyService.php
+++ b/models/classes/implementation/OntologyService.php
@@ -36,6 +36,9 @@ class OntologyService extends AbstractResultService
     /** @deprecated */
     const PROPERTY_RESULT_SERVER = 'http://www.tao.lu/Ontologies/TAODelivery.rdf#DeliveryResultServer';
 
+    /** @var bool $configurable Whether this ResultServerService instance is configurable */
+    protected $configurable = false;
+
     /**
      * Returns the storage engine of the result server
      *

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -69,6 +69,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('3.4.0');
         }
 
-        $this->skip('3.4.0', '5.0.0');
+        $this->skip('3.4.0', '5.0.1');
     }
 }


### PR DESCRIPTION
Now when in configuration file the `ResultServerService` class is stated as a default Result Server, the `Result Server` field will be hidden from delivery editing form;