### PR TITLE
create empty storage for no storage option

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '5.0.2',
+    'version' => '5.1.0',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/classes/NoResultStorage.php
+++ b/models/classes/NoResultStorage.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoResultServer\models\classes;
+
+use oat\oatbox\service\ConfigurableService;
+use taoResultServer_models_classes_Variable;
+use taoResultServer_models_classes_WritableResultStorage;
+
+class NoResultStorage extends ConfigurableService implements taoResultServer_models_classes_WritableResultStorage
+{
+    public function spawnResult()
+    {
+    }
+
+    public function storeRelatedTestTaker($deliveryResultIdentifier, $testTakerIdentifier)
+    {
+    }
+
+    public function storeRelatedDelivery($deliveryResultIdentifier, $deliveryIdentifier)
+    {
+    }
+
+    public function storeItemVariable($deliveryResultIdentifier, $test, $item, taoResultServer_models_classes_Variable $itemVariable, $callIdItem)
+    {
+    }
+
+    public function storeItemVariables($deliveryResultIdentifier, $test, $item, array $itemVariables, $callIdItem)
+    {
+    }
+
+    public function storeTestVariable($deliveryResultIdentifier, $test, taoResultServer_models_classes_Variable $testVariable, $callIdTest)
+    {
+    }
+
+    public function storeTestVariables($deliveryResultIdentifier, $test, array $testVariables, $callIdTest)
+    {
+    }
+
+    public function configure($callOptions = array())
+    {
+    }
+}

--- a/models/classes/NoResultStorageException.php
+++ b/models/classes/NoResultStorageException.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoResultServer\models\classes;
+
+class NoResultStorageException extends \common_exception_Error
+{
+    const MESSAGE = 'No Results are available. The No Storage for the delivery is selected.';
+
+    public static function create()
+    {
+        return new \common_exception_Error(static::MESSAGE);
+    }
+}

--- a/models/classes/implementation/OntologyService.php
+++ b/models/classes/implementation/OntologyService.php
@@ -40,7 +40,7 @@ class OntologyService extends AbstractResultService
      *
      * @param string $deliveryId
      * @throws \common_exception_Error
-     * @return \taoResultServer_models_classes_ReadableResultStorage|\taoResultServer_models_classes_WritableResultStorage|oat\taoResultServer\models\classes\ResultManagement
+     * @return \taoResultServer_models_classes_ReadableResultStorage
      */
     public function getResultStorage($deliveryId = null)
     {

--- a/models/ontology/taoResultServer.rdf
+++ b/models/ontology/taoResultServer.rdf
@@ -56,9 +56,17 @@
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </rdf:Description>
 
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultNoStorageModel">
+        <rdfs:label xml:lang="en-US"><![CDATA[tao logger]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Data about the result storage is sent to the logger]]></rdfs:comment>
+        <resultserver:implementation><![CDATA[oat\taoResultServer\models\classes\NoResultStorage]]></resultserver:implementation>
+        <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultNoStorageModel"/>
+    </rdf:Description>
+
    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOResultServer.rdf#void">
 	<rdfs:label xml:lang="en-US"><![CDATA[No storage]]></rdfs:label>
 	<rdfs:comment xml:lang="en-US"><![CDATA[No storage ]]></rdfs:comment>
+    <resultserver:hasResultServerModel rdf:resource="http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultNoStorageModel" />
 	<rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultServer"/>
    </rdf:Description>
 

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -19,6 +19,7 @@
  *
  */
 
+use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoResultServer\models\classes\ResultServerService;
 use oat\taoResultServer\models\classes\implementation\OntologyService;
 use oat\taoResultServer\models\classes\QtiResultsService;
@@ -70,5 +71,10 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
         }
 
         $this->skip('3.4.0', '5.0.2');
+
+        if ($this->isVersion('5.0.2')) {
+            OntologyUpdater::syncModels();
+            $this->skip('5.0.2', '5.1.0');
+        }
     }
 }


### PR DESCRIPTION
Steps to reproduce:
1. in config/taoResultServer/resultservice.conf.php use 
return new oat\taoResultServer\models\classes\implementation\OntologyService();
2. Select No Storage option for a delivery
3. Start the delivery, 500 error raised.
