### PR TITLE
Feature/tao 7481 separate itemresults by timestamp

### DIFF
--- a/models/classes/CrudResultsService.php
+++ b/models/classes/CrudResultsService.php
@@ -20,17 +20,16 @@
  */
 
 namespace oat\taoResultServer\models\classes;
+
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 
 /**
  * .Crud services implements basic CRUD services, orginally intended for REST controllers/ HTTP exception handlers
  *  Consequently the signatures and behaviors is closer to REST and throwing HTTP like exceptions
- *  
- *
- * 
  */
-class CrudResultsService extends \tao_models_classes_CrudService {
+class CrudResultsService extends \tao_models_classes_CrudService
+{
 
     const GROUP_BY_DELIVERY = 0;
     const GROUP_BY_TEST = 1;
@@ -38,60 +37,65 @@ class CrudResultsService extends \tao_models_classes_CrudService {
 
     protected $resultClass = null;
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         $this->resultClass = new \core_kernel_classes_Class(ResultService::DELIVERY_RESULT_CLASS_URI);
     }
 
-    public function getRootClass() {
+    public function getRootClass()
+    {
         return $this->resultClass;
     }
 
-    public function get($uri, $groupBy = self::GROUP_BY_DELIVERY) {
+    public function get($uri, $groupBy = self::GROUP_BY_DELIVERY)
+    {
         $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution($uri);
         $delivery = $deliveryExecution->getDelivery();
-    
+
         $resultService = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID);
         $implementation = $resultService->getResultStorage($delivery->getUri());
+
         return $this->format($implementation, $uri);
     }
-        
-    public function format(\taoResultServer_models_classes_ReadableResultStorage $resultStorage, $resultIdentifier, $groupBy = self::GROUP_BY_DELIVERY) {
+
+    public function format(\taoResultServer_models_classes_ReadableResultStorage $resultStorage, $resultIdentifier, $groupBy = self::GROUP_BY_DELIVERY)
+    {
         $returnData = array();
-        
+
         if ($groupBy === self::GROUP_BY_DELIVERY || $groupBy === self::GROUP_BY_ITEM) {
             $calls = $resultStorage->getRelatedItemCallIds($resultIdentifier);
         } else {
             $calls = $resultStorage->getRelatedTestCallIds($resultIdentifier);
         }
 
-        foreach($calls as $callId){
+        foreach ($calls as $callId) {
             $results = $resultStorage->getVariables($callId);
             $resource = array();
-                foreach($results as $result){
-                    $result = array_pop($result);
-                    if(isset($result->variable)){
-                        $resource['value'] = $result->variable->getValue();
-                        $resource['identifier'] = $result->variable->getIdentifier();
-                        if($result->variable instanceof \taoResultServer_models_classes_ResponseVariable){
-                            $type = "http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable";
-                        }
-                        else{
-                            $type = "http://www.tao.lu/Ontologies/TAOResult.rdf#OutcomeVariable";
-                        }
-                        $resource['type'] = new \core_kernel_classes_Class($type);
-                        $resource['epoch'] = $result->variable->getEpoch();
-                        $resource['cardinality'] = $result->variable->getCardinality();
-                        $resource['basetype'] = $result->variable->getBaseType();
-                    }
-
-                    if ($groupBy === self::GROUP_BY_DELIVERY) {
-                        $returnData[$resultIdentifier][] = $resource;
+            foreach ($results as $result) {
+                $result = array_pop($result);
+                if (isset($result->variable)) {
+                    $resource['value'] = $result->variable->getValue();
+                    $resource['identifier'] = $result->variable->getIdentifier();
+                    if ($result->variable instanceof \taoResultServer_models_classes_ResponseVariable) {
+                        $type = "http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable";
                     } else {
-                        $returnData[$callId][] = $resource;
+                        $type = "http://www.tao.lu/Ontologies/TAOResult.rdf#OutcomeVariable";
                     }
+                    $resource['type'] = new \core_kernel_classes_Class($type);
+                    $resource['epoch'] = $result->variable->getEpoch();
+                    $resource['cardinality'] = $result->variable->getCardinality();
+                    $resource['basetype'] = $result->variable->getBaseType();
                 }
+
+                if ($groupBy === self::GROUP_BY_DELIVERY) {
+                    $returnData[$resultIdentifier][] = $resource;
+                } else {
+                    $returnData[$callId][] = $resource;
+                }
+            }
         }
+
         return $returnData;
     }
 
@@ -109,13 +113,13 @@ class CrudResultsService extends \tao_models_classes_CrudService {
             // get delivery executions
 
             //get all info
-            foreach($implementation->getResultByDelivery(array($delivery)) as $result){
+            foreach ($implementation->getResultByDelivery(array($delivery)) as $result) {
                 $result = array_merge($result, array(RDFS_LABEL => $assembly->getLabel()));
                 $properties = array();
-                foreach($result as $key => $value){
+                foreach ($result as $key => $value) {
                     $property = array();
                     $type = 'resource';
-                    switch($key){
+                    switch ($key) {
                         case 'deliveryResultIdentifier':
                             $property['predicateUri'] = "http://www.tao.lu/Ontologies/TAOResult.rdf#Identifier";
                             break;
@@ -136,27 +140,29 @@ class CrudResultsService extends \tao_models_classes_CrudService {
 
                 }
                 $resources[] = array(
-                    'uri'           => $result['deliveryResultIdentifier'],
-                    'properties'    => $properties
+                    'uri' => $result['deliveryResultIdentifier'],
+                    'properties' => $properties
                 );
             }
         }
+
         return $resources;
     }
 
 
-
-    public function delete($resource) {
-       throw new \common_exception_NoImplementation();
-    }
-
-    public function deleteAll() {
+    public function delete($resource)
+    {
         throw new \common_exception_NoImplementation();
     }
 
-   
+    public function deleteAll()
+    {
+        throw new \common_exception_NoImplementation();
+    }
 
-    public function update($uri = null, $propertiesValues = array()) {
+
+    public function update($uri = null, $propertiesValues = array())
+    {
         throw new \common_exception_NoImplementation();
     }
 
@@ -174,5 +180,4 @@ class CrudResultsService extends \tao_models_classes_CrudService {
     {
         // TODO: Implement getClassService() method.
     }
-
 }

--- a/models/classes/QtiToXmlConverter.php
+++ b/models/classes/QtiToXmlConverter.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoResultServer\models\classes;
+
+use qtism\common\enums\Cardinality;
+
+class QtiToXmlConverter
+{
+    const QTI_NS = 'http://www.imsglobal.org/xsd/imsqti_result_v2p1';
+
+    /**
+     * Converts Qti results to xml.
+     *
+     * @param $testTaker
+     * @param $testResults
+     * @param $itemResults
+     * @return string
+     * @throws \common_Exception when timestamp is not recognized
+     */
+    public function convertToXml($testTaker, $testResults, $itemResults)
+    {
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+
+        $assessmentResultElt = $dom->createElementNS(self::QTI_NS, 'assessmentResult');
+        $dom->appendChild($assessmentResultElt);
+
+        /** Context */
+        $contextElt = $dom->createElementNS(self::QTI_NS, 'context');
+        $contextElt->setAttribute('sourcedId', \tao_helpers_Uri::getUniqueId($testTaker));
+        $assessmentResultElt->appendChild($contextElt);
+
+        /** Test Result */
+        foreach ($testResults as $testResultIdentifier => $testResult) {
+            $identifierParts = explode('.', $testResultIdentifier);
+            $testIdentifier = array_pop($identifierParts);
+
+            $testResultElement = $dom->createElementNS(self::QTI_NS, 'testResult');
+            $testResultElement->setAttribute('identifier', $testIdentifier);
+            $testResultElement->setAttribute('datestamp', \tao_helpers_Date::displayeDate(
+                $testResult[0]['epoch'],
+                \tao_helpers_Date::FORMAT_ISO8601
+            ));
+
+            /** Item Variable */
+            foreach ($testResult as $itemVariable) {
+                $isResponseVariable = $this->isResponseVariable($itemVariable);
+                $testVariableElement = $dom->createElementNS(self::QTI_NS, ($isResponseVariable) ? 'responseVariable' : 'outcomeVariable');
+                $testVariableElement->setAttribute('identifier', $itemVariable['identifier']);
+                $testVariableElement->setAttribute('cardinality', $itemVariable['cardinality']);
+                $testVariableElement->setAttribute('baseType', $itemVariable['basetype']);
+
+                $valueElement = $this->createCDATANode($dom, 'value', trim($itemVariable['value']));
+
+                if ($isResponseVariable) {
+                    $candidateResponseElement = $dom->createElementNS(self::QTI_NS, 'candidateResponse');
+                    $candidateResponseElement->appendChild($valueElement);
+                    $testVariableElement->appendChild($candidateResponseElement);
+                } else {
+                    $testVariableElement->appendChild($valueElement);
+                }
+
+                $testResultElement->appendChild($testVariableElement);
+            }
+
+            $assessmentResultElt->appendChild($testResultElement);
+        }
+
+        /** Item Result */
+        foreach ($itemResults as $itemResultIdentifier => $itemResult) {
+
+            // Retrieve identifier.
+            $identifierParts = explode('.', $itemResultIdentifier);
+            array_pop($identifierParts);
+            $refIdentifier = array_pop($identifierParts);
+
+            $itemElement = $dom->createElementNS(self::QTI_NS, 'itemResult');
+            $itemElement->setAttribute('identifier', $refIdentifier);
+            $itemElement->setAttribute('datestamp', \tao_helpers_Date::displayeDate(
+                $itemResult[0]['epoch'],
+                \tao_helpers_Date::FORMAT_ISO8601
+            ));
+            $itemElement->setAttribute('sessionStatus', 'final');
+
+            /** Item variables */
+            foreach ($itemResult as $key => $itemVariable) {
+                $isResponseVariable = $this->isResponseVariable($itemVariable);
+
+                if ($itemVariable['identifier'] == 'comment') {
+                    /** Comment */
+                    $itemVariableElement = $dom->createElementNS(self::QTI_NS, 'candidateComment', $itemVariable['value']);
+                } else {
+                    /** Item variable */
+                    $itemVariableElement = $dom->createElementNS(self::QTI_NS, ($isResponseVariable) ? 'responseVariable' : 'outcomeVariable');
+                    $itemVariableElement->setAttribute('identifier', $itemVariable['identifier']);
+                    $itemVariableElement->setAttribute('cardinality', $itemVariable['cardinality']);
+                    $itemVariableElement->setAttribute('baseType', $itemVariable['basetype']);
+
+                    /** Split multiple response */
+                    $itemVariable['value'] = trim($itemVariable['value'], '[]');
+                    if ($itemVariable['cardinality'] !== Cardinality::getNameByConstant(Cardinality::SINGLE)) {
+                        $values = explode(';', $itemVariable['value']);
+                        $returnValue = [];
+                        foreach ($values as $value) {
+                            $returnValue[] = $this->createCDATANode($dom, 'value', $value);
+                        }
+                    } else {
+                        $returnValue = $this->createCDATANode($dom, 'value', $itemVariable['value']);
+                    }
+
+                    /** Get response parent element */
+                    if ($isResponseVariable) {
+                        /** Response variable */
+                        $responseElement = $dom->createElementNS(self::QTI_NS, 'candidateResponse');
+                    } else {
+                        /** Outcome variable */
+                        $responseElement = $itemVariableElement;
+                    }
+
+                    /** Write a response node foreach answer  */
+                    if (is_array($returnValue)) {
+                        foreach ($returnValue as $valueElement) {
+                            $responseElement->appendChild($valueElement);
+                        }
+                    } else {
+                        $responseElement->appendChild($returnValue);
+                    }
+
+                    if ($isResponseVariable) {
+                        $itemVariableElement->appendChild($responseElement);
+                    }
+                }
+
+                $itemElement->appendChild($itemVariableElement);
+            }
+
+            $assessmentResultElt->appendChild($itemElement);
+        }
+
+        return $dom->saveXML();
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     * @param string $tag Xml tag to create
+     * @param string $data Data to escape
+     * @return \DOMElement
+     */
+    protected function createCDATANode($dom, $tag, $data)
+    {
+        $node = $dom->createCDATASection($data);
+        $returnValue = $dom->createElementNS(self::QTI_NS, $tag);
+        $returnValue->appendChild($node);
+        return $returnValue;
+    }
+
+    /**
+     * Is a variable a response variable?
+     *
+     * @param array $itemVariable
+     * @return bool
+     */
+    protected function isResponseVariable(array $itemVariable)
+    {
+        if (!isset($itemVariable['type']) || !$itemVariable['type'] instanceof \core_kernel_classes_Class) {
+            return false;
+        }
+        return $itemVariable['type']->getUri() === 'http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable';
+    }
+}

--- a/test/unit/models/classes/CrudResultsServiceTest.php
+++ b/test/unit/models/classes/CrudResultsServiceTest.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace oat\taoResultServer\models\classes;
+
+use oat\generis\test\TestCase;
+
+class CrudResultsServiceTest extends TestCase
+{
+    /**
+     * @var CrudResultsService
+     */
+    private $sut;
+
+    public function setUp()
+    {
+        $this->sut = new CrudResultsService();
+    }
+
+    /**
+     * @dataProvider variablesToTest
+     */
+    public function testReadQtiResult_ByItem($resultIdentifier, $variables, $groupBy, $returnAttempts, $qtiResult)
+    {
+        /** @var \PHPUnit_Framework_MockObject_MockObject|ResultManagement $resultStorage */
+        $resultStorage = $this->getMockForAbstractClass(ResultManagement::class);
+
+        $resultStorage->method('getRelatedItemCallIds')->willReturn([$resultIdentifier]);
+        $resultStorage->method('getRelatedTestCallIds')->willReturn([$resultIdentifier]);
+        $resultStorage->method('getVariables')->willReturn($variables);
+
+        $this->assertEquals($qtiResult[$groupBy], $this->sut->readQtiResult($resultStorage, $resultIdentifier, $groupBy, $returnAttempts));
+    }
+
+    public function variablesToTest()
+    {
+        $deliveryResultIdentifier = 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495620683550142';
+        $testValue = '0';
+        $testId = 'LtiOutcome';
+        $testType = 'float';
+        $timestamp1 = '1549562079';
+        $timestamp2 = '1549562096';
+        $milliseconds1 = '0.54604200';
+        $milliseconds2 = '0.54604900';
+        $attemptId = 'numAttempts';
+        $attemptType = 'integer';
+        $attempt1 = 1;
+        $attempt2 = 2;
+        $durationId = 'duration';
+        $durationType = 'duration';
+        $duration1 = 'PT5.419702S';
+        $duration2 = 'PT11.151032S';
+        $cardinality = 'single';
+
+        $variables = [
+            'rds' => [
+                198 => [
+                    $this->buildVariable([
+                        'uri' => 198,
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $attempt1,
+                        'identifier' => $attemptId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $attemptType,
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ]),
+                ],
+                199 => [
+                    $this->buildVariable([
+                        'uri' => 199,
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $duration1,
+                        'identifier' => $durationId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $durationType,
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ]),
+                ],
+
+                211 => [
+                    $this->buildVariable([
+                        'uri' => 211,
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $attempt2,
+                        'identifier' => $attemptId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $attemptType,
+                        'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                    ]),
+                ],
+                212 => [
+                    $this->buildVariable([
+                        'uri' => 212,
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $duration2,
+                        'identifier' => $durationId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $durationType,
+                        'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                    ]),
+                ],
+            ],
+            'rds-test' => [
+                224 => [
+                    $this->buildVariable([
+                        'uri' => 224,
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'value' => '0',
+                        'identifier' => 'LtiOutcome',
+                        'cardinality' => $cardinality,
+                        'baseType' => 'float',
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ], true),
+                ],
+            ],
+            'kv' => [
+                'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0numAttempts' => [
+                    $this->buildVariable([
+                        'uri' => 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0_prop_numAttempts',
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $attempt1,
+                        'identifier' => $attemptId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $attemptType,
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ]),
+                    $this->buildVariable([
+                        'uri' => 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0_prop_numAttempts',
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $attempt2,
+                        'identifier' => $attemptId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $attemptType,
+                        'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                    ]),
+                ],
+                'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0duration' => [
+                    $this->buildVariable([
+                        'uri' => 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0_prop_duration',
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $duration1,
+                        'identifier' => $durationId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $durationType,
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ]),
+                    $this->buildVariable([
+                        'uri' => 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197.item-1.0_prop_duration',
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'candidateResponse' => $duration2,
+                        'identifier' => $durationId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $durationType,
+                        'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                    ]),
+                ],
+            ],
+            'kv-test' => [
+                'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197LtiOutcome' => [
+                    $this->buildVariable([
+                        'uri' => 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549623919594197_prop_LtiOutcome',
+                        'deliveryResultIdentifier' => $deliveryResultIdentifier,
+                        'value' => $testValue,
+                        'identifier' => $testId,
+                        'cardinality' => $cardinality,
+                        'baseType' => $testType,
+                        'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                    ], true),
+                ],
+            ],
+        ];
+
+        $results = [
+            'attempt1' => [
+                'value' => $attempt1,
+                'identifier' => $attemptId,
+                'type' => new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable'),
+                'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                'cardinality' => $cardinality,
+                'basetype' => $attemptType,
+            ],
+            'duration1' => [
+                'value' => $duration1,
+                'identifier' => $durationId,
+                'type' => new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable'),
+                'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                'cardinality' => $cardinality,
+                'basetype' => $durationType,
+
+            ],
+            'attempt2' => [
+                'value' => $attempt2,
+                'identifier' => $attemptId,
+                'type' => new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable'),
+                'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                'cardinality' => $cardinality,
+                'basetype' => $attemptType,
+
+            ],
+            'duration2' => [
+                'value' => $duration2,
+                'identifier' => $durationId,
+                'type' => new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable'),
+                'epoch' => $milliseconds2 . ' ' . $timestamp2,
+                'cardinality' => $cardinality,
+                'basetype' => $durationType,
+            ],
+            'test' => [
+                'value' => $testValue,
+                'identifier' => $testId,
+                'type' => new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#OutcomeVariable'),
+                'epoch' => $milliseconds1 . ' ' . $timestamp1,
+                'cardinality' => $cardinality,
+                'basetype' => $testType,
+            ],
+        ];
+
+        $qtiResult = [
+            CrudResultsService::GROUP_BY_ITEM => [
+                $timestamp1 . $deliveryResultIdentifier => [
+                    $results['attempt1'],
+                    $results['duration1'],
+                ],
+                $timestamp2 . $deliveryResultIdentifier => [
+                    $results['attempt2'],
+                    $results['duration2'],
+                ],
+            ],
+            CrudResultsService::GROUP_BY_DELIVERY => [
+                $timestamp2 . $deliveryResultIdentifier => [
+                    $results['attempt2'],
+                    $results['duration2'],
+                ],
+            ],
+            CrudResultsService::GROUP_BY_TEST => [
+                $deliveryResultIdentifier => [
+                    $results['test'],
+                ],
+            ],
+        ];
+
+        return [
+            'rds-item' => [
+                $deliveryResultIdentifier,
+                $variables['rds'],
+                CrudResultsService::GROUP_BY_ITEM,
+                CrudResultsService::ATTEMPTS_ALL,
+                $qtiResult,
+            ],
+
+            'kv-item' => [
+                $deliveryResultIdentifier,
+                $variables['kv'],
+                CrudResultsService::GROUP_BY_ITEM,
+                CrudResultsService::ATTEMPTS_ALL,
+                $qtiResult,
+            ],
+
+            'rds-delivery' => [
+                $deliveryResultIdentifier,
+                $variables['rds'],
+                CrudResultsService::GROUP_BY_DELIVERY,
+                CrudResultsService::ATTEMPTS_LATEST,
+                $qtiResult,
+            ],
+
+            'kv-delivery' => [
+                $deliveryResultIdentifier,
+                $variables['kv'],
+                CrudResultsService::GROUP_BY_DELIVERY,
+                CrudResultsService::ATTEMPTS_LATEST,
+                $qtiResult,
+            ],
+
+            'rds-test' => [
+                $deliveryResultIdentifier,
+                $variables['rds-test'],
+                CrudResultsService::GROUP_BY_TEST,
+                CrudResultsService::ATTEMPTS_NONE,
+                $qtiResult,
+            ],
+
+            'kv-test' => [
+                $deliveryResultIdentifier,
+                $variables['kv-test'],
+                CrudResultsService::GROUP_BY_TEST,
+                CrudResultsService::ATTEMPTS_NONE,
+                $qtiResult,
+            ],
+        ];
+    }
+
+    protected function buildVariable(array $properties, $test = false)
+    {
+        $class = $test
+            ? 'taoResultServer_models_classes_OutcomeVariable'
+            : 'taoResultServer_models_classes_ResponseVariable';
+        $callIdItem = $test ? null : 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549558434108966';
+        $callIdTest = $test ? 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495620683550142' : null;
+        $testUri = 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495616427232134-';
+        $itemUri = $test ? null : 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549558434108966';
+        $correctResponse = null;
+
+        $namespacedClass = '\\' . $class;
+        $variable = new $namespacedClass();
+        $variable->correctResponse = $correctResponse;
+        if ($test) {
+            $variable->value = base64_encode($properties['value']);
+        } else {
+            $variable->candidateResponse = base64_encode($properties['candidateResponse']);
+        }
+        $variable->identifier = $properties['identifier'];
+        $variable->cardinality = $properties['cardinality'];
+        $variable->baseType = $properties['baseType'];
+        $variable->epoch = $properties['epoch'];
+
+        $container = new \stdClass();
+        $container->uri = $properties['uri'];
+        $container->class = $class;
+        $container->deliveryResultIdentifier = $properties['deliveryResultIdentifier'];
+        $container->callIdItem = $callIdItem;
+        $container->callIdTest = $callIdTest;
+        $container->test = $testUri;
+        $container->item = $itemUri;
+        $container->variable = $variable;
+
+        return $container;
+    }
+}

--- a/test/unit/models/classes/QtiToXmlConverterTest.php
+++ b/test/unit/models/classes/QtiToXmlConverterTest.php
@@ -1,0 +1,379 @@
+<?php
+
+namespace oat\taoResultServer\models\classes;
+
+use oat\generis\test\TestCase;
+
+class QtiToXmlConverterTest extends TestCase
+{
+    /** @var QtiToXmlConverter */
+    private $sut;
+
+    public function setUp()
+    {
+        $this->sut = new QtiToXmlConverter();
+    }
+
+    /**
+     * @dataProvider expected
+     */
+    public function testConvertToXml($testTaker, $testResults, $itemResults, $expected)
+    {
+        $this->assertEquals($expected, $this->sut->convertToXml($testTaker, $testResults, $itemResults));
+    }
+
+    public function expected()
+    {
+        $testTaker = 'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i1549443724964951';
+
+        $outcomeVariable = new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#OutcomeVariable');
+        $responseVariable = new \core_kernel_classes_Class('http://www.tao.lu/Ontologies/TAOResult.rdf#ResponseVariable');
+
+        $testResults = [
+            'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495620683550142' => [
+                [
+                    'value' => '0',
+                    'identifier' => 'LtiOutcome',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.46565800 1549562103',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+            ],
+        ];
+
+        $itemResults = [
+            'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495620683550142.item-1.0' => [
+                [
+                    'value' => '1',
+                    'identifier' => 'numAttempts',
+                    'type' => $responseVariable,
+                    'epoch' => '0.54604200 1549562079',
+                    'cardinality' => 'single',
+                    'basetype' => 'integer',
+                ],
+                [
+                    'value' => 'PT5.419702S',
+                    'identifier' => 'duration',
+                    'type' => $responseVariable,
+                    'epoch' => '0.54604900 1549562079',
+                    'cardinality' => 'single',
+                    'basetype' => 'duration',
+                ],
+                [
+                    'value' => 'completed',
+                    'identifier' => 'completionStatus',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.54605100 1549562079',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'SCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.54605300 1549562079',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'MAXSCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.54605500 1549562079',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '[\'choice_1\']',
+                    'identifier' => 'RESPONSE',
+                    'type' => $responseVariable,
+                    'epoch' => '0.54605600 1549562079',
+                    'cardinality' => 'multiple',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '2',
+                    'identifier' => 'numAttempts',
+                    'type' => $responseVariable,
+                    'epoch' => '0.31206000 1549562096',
+                    'cardinality' => 'single',
+                    'basetype' => 'integer',
+                ],
+                [
+                    'value' => 'PT11.151032S',
+                    'identifier' => 'duration',
+                    'type' => $responseVariable,
+                    'epoch' => '0.31207200 1549562096',
+                    'cardinality' => 'single',
+                    'basetype' => 'duration',
+                ],
+                [
+                    'value' => 'completed',
+                    'identifier' => 'completionStatus',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.31207500 1549562096',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '0',
+                    'identifier' => 'SCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.31207800 1549562096',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'MAXSCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.31208000 1549562096',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '[\'choice_2\']',
+                    'identifier' => 'RESPONSE',
+                    'type' => $responseVariable,
+                    'epoch' => '0.31208200 1549562096',
+                    'cardinality' => 'multiple',
+                    'basetype' => 'identifier',
+                ],
+            ],
+            'http://127.0.0.1/oat/package-tao/tao-gui-installed.rdf#i15495620683550142.item-2.0' => [
+                [
+                    'value' => '1',
+                    'identifier' => 'numAttempts',
+                    'type' => $responseVariable,
+                    'epoch' => '0.96892200 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'integer',
+                ],
+                [
+                    'value' => 'PT7.363893S',
+                    'identifier' => 'duration',
+                    'type' => $responseVariable,
+                    'epoch' => '0.96895000 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'duration',
+                ],
+                [
+                    'value' => 'completed',
+                    'identifier' => 'completionStatus',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.96895500 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'SCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.96895800 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'MAXSCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.96896100 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => 'feedbackModal_1',
+                    'identifier' => 'FEEDBACK_1',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.96896400 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => 'choice_1',
+                    'identifier' => 'RESPONSE',
+                    'type' => $responseVariable,
+                    'epoch' => '0.96896700 1549562086',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '2',
+                    'identifier' => 'numAttempts',
+                    'type' => $responseVariable,
+                    'epoch' => '0.35095700 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'integer',
+                ],
+                [
+                    'value' => 'PT11.362917S',
+                    'identifier' => 'duration',
+                    'type' => $responseVariable,
+                    'epoch' => '0.35098600 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'duration',
+                ],
+                [
+                    'value' => 'completed',
+                    'identifier' => 'completionStatus',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.35099100 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => '0',
+                    'identifier' => 'SCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.35099400 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => '1',
+                    'identifier' => 'MAXSCORE',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.35099800 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'float',
+                ],
+                [
+                    'value' => 'feedbackModal_2',
+                    'identifier' => 'FEEDBACK_1',
+                    'type' => $outcomeVariable,
+                    'epoch' => '0.35100000 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+                [
+                    'value' => 'choice_3',
+                    'identifier' => 'RESPONSE',
+                    'type' => $responseVariable,
+                    'epoch' => '0.35100300 1549562100',
+                    'cardinality' => 'single',
+                    'basetype' => 'identifier',
+                ],
+            ],
+        ];
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1">
+  <context sourcedId="i1549443724964951"/>
+  <testResult identifier="rdf#i15495620683550142" datestamp="2019-02-07T17:55:03.466">
+    <outcomeVariable identifier="LtiOutcome" cardinality="single" baseType="float">
+      <value><![CDATA[0]]></value>
+    </outcomeVariable>
+  </testResult>
+  <itemResult identifier="item-1" datestamp="2019-02-07T17:54:39.546" sessionStatus="final">
+    <responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
+      <candidateResponse>
+        <value><![CDATA[1]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="duration" cardinality="single" baseType="duration">
+      <candidateResponse>
+        <value><![CDATA[PT5.419702S]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
+      <value><![CDATA[completed]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <responseVariable identifier="RESPONSE" cardinality="multiple" baseType="identifier">
+      <candidateResponse>
+        <value><![CDATA[\'choice_1\']]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
+      <candidateResponse>
+        <value><![CDATA[2]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="duration" cardinality="single" baseType="duration">
+      <candidateResponse>
+        <value><![CDATA[PT11.151032S]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
+      <value><![CDATA[completed]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
+      <value><![CDATA[0]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <responseVariable identifier="RESPONSE" cardinality="multiple" baseType="identifier">
+      <candidateResponse>
+        <value><![CDATA[\'choice_2\']]></value>
+      </candidateResponse>
+    </responseVariable>
+  </itemResult>
+  <itemResult identifier="item-2" datestamp="2019-02-07T17:54:46.969" sessionStatus="final">
+    <responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
+      <candidateResponse>
+        <value><![CDATA[1]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="duration" cardinality="single" baseType="duration">
+      <candidateResponse>
+        <value><![CDATA[PT7.363893S]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
+      <value><![CDATA[completed]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="FEEDBACK_1" cardinality="single" baseType="identifier">
+      <value><![CDATA[feedbackModal_1]]></value>
+    </outcomeVariable>
+    <responseVariable identifier="RESPONSE" cardinality="single" baseType="identifier">
+      <candidateResponse>
+        <value><![CDATA[choice_1]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="numAttempts" cardinality="single" baseType="integer">
+      <candidateResponse>
+        <value><![CDATA[2]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <responseVariable identifier="duration" cardinality="single" baseType="duration">
+      <candidateResponse>
+        <value><![CDATA[PT11.362917S]]></value>
+      </candidateResponse>
+    </responseVariable>
+    <outcomeVariable identifier="completionStatus" cardinality="single" baseType="identifier">
+      <value><![CDATA[completed]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="SCORE" cardinality="single" baseType="float">
+      <value><![CDATA[0]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="MAXSCORE" cardinality="single" baseType="float">
+      <value><![CDATA[1]]></value>
+    </outcomeVariable>
+    <outcomeVariable identifier="FEEDBACK_1" cardinality="single" baseType="identifier">
+      <value><![CDATA[feedbackModal_2]]></value>
+    </outcomeVariable>
+    <responseVariable identifier="RESPONSE" cardinality="single" baseType="identifier">
+      <candidateResponse>
+        <value><![CDATA[choice_3]]></value>
+      </candidateResponse>
+    </responseVariable>
+  </itemResult>
+</assessmentResult>
+';
+
+        return [[$testTaker, $testResults, $itemResults, $xml]];
+    }
+}


### PR DESCRIPTION
Renamed CrudResultsService::format to CrudResultsService::readQtiResult.
Added a configuration parameter to this method to either return:
ATTEMPTS_NONE: no attempt (default for Test results)
ATTEMPTS_ALL: all attempts sorted by timstamps increasing
ATTEMPTS_LATEST: latest attempt only
