### PR TITLE
Fix/act 306/add delete delivery execution data to no result storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '9.2.0',
+    'version' => '9.2.1',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/classes/NoResultStorage.php
+++ b/models/classes/NoResultStorage.php
@@ -57,4 +57,8 @@ class NoResultStorage extends ConfigurableService implements taoResultServer_mod
     public function configure($callOptions = array())
     {
     }
+
+    public function deleteDeliveryExecutionData()
+    {
+    }
 }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -77,6 +77,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('5.1.0');
         }
 
-        $this->skip('5.1.0', '9.2.0');
+        $this->skip('5.1.0', '9.2.1');
     }
 }


### PR DESCRIPTION
`DeliveryDeleteTask` was failed with the following message:
```
Executing task http://localhost/tao.rdf#i15616944390919057001282609 failed with MSG: Call to undefined method oat\\taoResultServer\\models\\classes\\NoResultStorage::deleteDeliveryExecutionData()
```