### PR TITLE
Tao 8802 duplicate variable exception

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '9.2.2',
+    'version' => '9.3.0',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/Exceptions/DuplicateVariableException.php
+++ b/models/Exceptions/DuplicateVariableException.php
@@ -20,14 +20,18 @@
 
 namespace oat\taoResultServer\models\Exceptions;
 
-use Exception;
+use common_Exception;
 
 /**
  * Class DuplicateVariableException
+ *
+ * This exception must be thrown during attempt to store non-unique value in the result storage.
+ * Uniqueness is based on combination of `result id` and `variable value` columns
+ *
  * @package oat\taoResultServer\models\Exceptions
  * @author Aleh Hutnikau, <huntikau@1pt.com>
  */
-class DuplicateVariableException extends Exception
+class DuplicateVariableException extends common_Exception
 {
 
 }

--- a/models/Exceptions/DuplicateVariableException.php
+++ b/models/Exceptions/DuplicateVariableException.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoResultServer\models\Exceptions;
+
+use Exception;
+
+/**
+ * Class DuplicateVariableException
+ * @package oat\taoResultServer\models\Exceptions
+ * @author Aleh Hutnikau, <huntikau@1pt.com>
+ */
+class DuplicateVariableException extends Exception
+{
+
+}

--- a/models/classes/interface.WritableResultStorage.php
+++ b/models/classes/interface.WritableResultStorage.php
@@ -18,6 +18,8 @@
  *
  */
 
+use oat\taoResultServer\models\Exceptions\DuplicateVariableException;
+
 /**
  * The WritableResultStorage interface.
  * 
@@ -57,7 +59,6 @@ interface taoResultServer_models_classes_WritableResultStorage {
      * 
      * @param string $deliveryResultIdentifier The identifier of the Delivery Result (usually a Delivery Execution URI).
      * @param string $testTakerIdentifier The identifier of the Test Taker (usually a URI).
-     *
      */
     public function storeRelatedTestTaker($deliveryResultIdentifier, $testTakerIdentifier);
 
@@ -82,10 +83,19 @@ interface taoResultServer_models_classes_WritableResultStorage {
      * @param string $item (uri recommended)
      * @param taoResultServer_models_classes_Variable $itemVariable the variable to store
      * @param string $callIdItem contextual call id for the variable, ex. :  to distinguish the same variable output by the same item and that is presented several times in the same test
-     * 
+     * @throws DuplicateVariableException
      */
     public function storeItemVariable($deliveryResultIdentifier, $test, $item, taoResultServer_models_classes_Variable $itemVariable, $callIdItem);
-    
+
+    /**
+     * @param $deliveryResultIdentifier
+     * @param $test
+     * @param $item
+     * @param array $itemVariables
+     * @param $callIdItem
+     * @return mixed
+     * @throws DuplicateVariableException
+     */
     public function storeItemVariables($deliveryResultIdentifier, $test, $item, array $itemVariables, $callIdItem);
 
     /**
@@ -97,9 +107,18 @@ interface taoResultServer_models_classes_WritableResultStorage {
      * @param string $test
      * @param taoResultServer_models_classes_Variable $testVariable
      * @param $callIdTest
+     * @throws DuplicateVariableException
      */
     public function storeTestVariable($deliveryResultIdentifier, $test, taoResultServer_models_classes_Variable $testVariable, $callIdTest);
 
+    /**
+     * @param $deliveryResultIdentifier
+     * @param $test
+     * @param array $testVariables
+     * @param $callIdTest
+     * @return mixed
+     * @throws DuplicateVariableException
+     */
     public function storeTestVariables($deliveryResultIdentifier, $test, array $testVariables, $callIdTest);
     
     /**

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -77,6 +77,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('5.1.0');
         }
 
-        $this->skip('5.1.0', '9.2.2');
+        $this->skip('5.1.0', '9.3.0');
     }
 }


### PR DESCRIPTION
Records in the results storage must be unique.
A unique constraint by delivery execution id and variable will be added to the result storage table.
During attempt to store non-unique variable `DuplicateVariableException` will be thrown.