### PR TITLE
Fix/nex 321/empty candidate response

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -13,7 +13,7 @@ return array(
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '10.1.0',
+    'version' => '10.1.1',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
 	'requires' => array(

--- a/models/Mapper/ResultMapper.php
+++ b/models/Mapper/ResultMapper.php
@@ -282,7 +282,9 @@ class ResultMapper extends ConfigurableService
             new taoResultServer_models_classes_ResponseVariable()
         );
 
-        $variable->setCandidateResponse($this->serializeValueCollection($itemVariable->getCandidateResponse()->getValues()));
+        if ($itemVariable->getCandidateResponse()->hasValues()) {
+            $variable->setCandidateResponse($this->serializeValueCollection($itemVariable->getCandidateResponse()->getValues()));
+        }
 
         if ($itemVariable->hasCorrectResponse()) {
             $variable->setCorrectResponse($this->serializeValueCollection($itemVariable->getCorrectResponse()->getValues()));

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -77,6 +77,6 @@ class taoResultServer_scripts_update_Updater extends \common_ext_ExtensionUpdate
             $this->setVersion('5.1.0');
         }
 
-        $this->skip('5.1.0', '10.1.0');
+        $this->skip('5.1.0', '10.1.1');
     }
 }

--- a/test/resources/result/simple-assessment-result.xml
+++ b/test/resources/result/simple-assessment-result.xml
@@ -49,4 +49,15 @@
             <value>fixture-value19</value>
         </outcomeVariable>
     </itemResult>
+    <itemResult identifier="fixture-identifier-itemResult3" datestamp="2018-06-27T09:43:45.529" sessionStatus="final" sequenceIndex="2">
+        <responseVariable cardinality="single" identifier="fixture-identifier5" baseType="identifier" choiceSequence="value-id-1">
+            <correctResponse>
+                <value>fixture-value20</value>
+            </correctResponse>
+            <candidateResponse/>
+        </responseVariable>
+        <outcomeVariable cardinality="single" identifier="fixture-identifier6" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="4" normalMaximum="6" masteryValue="5">
+            <value>fixture-value19</value>
+        </outcomeVariable>
+    </itemResult>
 </assessmentResult>

--- a/test/unit/models/Mapper/ResultMapperTest.php
+++ b/test/unit/models/Mapper/ResultMapperTest.php
@@ -118,7 +118,7 @@ class ResultMapperTest extends TestCase
     public function testGetItemVariables()
     {
         $variablesByItemResult = $this->load()->getItemVariables();
-        $this->assertCount(2, $variablesByItemResult);
+        $this->assertCount(3, $variablesByItemResult);
 
         $this->assertArrayHasKey('fixture-identifier-itemResult1', $variablesByItemResult);
         $this->assertArrayHasKey('fixture-identifier-itemResult2', $variablesByItemResult);
@@ -170,6 +170,16 @@ class ResultMapperTest extends TestCase
         $this->assertEquals('string', $variable3->getBaseType());
         $epochDateTime = (new DateTime())->setTimestamp(explode(' ',$variable3->getEpoch())[1]);
         $this->assertSame('2018-06-27T09:41:45', $epochDateTime->format('Y-m-d\TH:i:s'));
+
+        /** @var taoResultServer_models_classes_ResponseVariable $variable4 */
+        $variable4 = $variablesByItemResult['fixture-identifier-itemResult3'][0];
+        $this->assertInstanceOf(\taoResultServer_models_classes_ResponseVariable::class, $variable4);
+        $this->assertEquals('fixture-identifier5', $variable4->getIdentifier());
+        $this->assertEmpty($variable4->getValue());
+        $this->assertEmpty($variable4->getCandidateResponse());
+        $this->assertEquals('fixture-value20', $variable4->getCorrectResponse());
+        $this->assertEquals('single', $variable4->getCardinality());
+        $this->assertEquals('identifier', $variable4->getBaseType());
     }
 
     public function testGetItemVariablesWithTemplateVariables()


### PR DESCRIPTION
While dealing with XML Results, containing self-closed `<candidateResponse/>` elements (corresponding to NULL or empty string), the `ResultMapper` class produces the following error

```
Argument 1 passed to oat\taoResultServer\models\Mapper\ResultMapper::serializeValueCollection() must be an instance of qtism\data\state\ValueCollection, null given, called in /var/www/html/taoResultServer/models/Mapper/ResultMapper.php on line 285 
```

An additional check in the `ResultMapper` implementation has been added in order to solve the issue.