### PR TITLE
Require taoOutcomeRds

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -15,12 +15,13 @@ return [
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '12.2.2',
+    'version' => '12.3.0',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
     'requires' => [
         'generis' => '>=12.15.0',
-        'tao' => '>=27.2.0'
+        'tao' => '>=27.2.0',
+        'taoOutcomeRds' => '>=7.3.2'
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAOResultServer.rdf#'


### PR DESCRIPTION
This changes applied because of service from taoOutcomeRds used by default in the result server configuration.
https://github.com/oat-sa/extension-tao-outcome/blob/master/config/default/resultservice.conf.php#L12
```php
return new ResultServerService([
    ResultServerService::OPTION_RESULT_STORAGE => 'taoOutcomeRds/RdsResultStorage'
]);
```
If by any reason `taoOutcomeRds` is not installed, it brakes delivery launch.

It is done during work on [BSA-104](https://oat-sa.atlassian.net/browse/BSA-104)