### PR TITLE
Fix/source id with int

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -15,7 +15,7 @@ return [
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '12.3.1',
+    'version' => '12.3.2',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
     'requires' => [

--- a/models/classes/QtiResultsService.php
+++ b/models/classes/QtiResultsService.php
@@ -147,6 +147,8 @@ class QtiResultsService extends ConfigurableService implements ResultService
         $userId = $resultServer->getTestTaker($deId);
         if (\common_Utils::isUri($userId)) {
             $userId = \tao_helpers_Uri::getUniqueId($userId);
+        } elseif (is_int($userId)) {
+            $userId = '#'.$userId;
         }
         $contextElt->setAttribute('sourcedId', $userId);
         $assessmentResultElt->appendChild($contextElt);


### PR DESCRIPTION
if we have results for a TT with  integer ID (for example was generated by LTI), then a XML with results will be invalid with the next message:
`XML injection failure: The document could not be validated with XML Schema '/var/www/html/tao/vendor/qtism/qtism/qtism/data/storage/xml/versions/../schemes/qtiv2p1/imsqti_result_v2p1.xsd':
Error: Element '{http://www.imsglobal.org/xsd/imsqti_result_v2p1}context', attribute 'sourcedId': '111' is not a valid value of the atomic type '{http://www.imsglobal.org/xsd/imsqti_result_v2p1}Identifier.Type'. at 3:0.`