### PR TITLE
Fix/re 55/fix error 500 when retrieving xml result on non existing entity

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -15,7 +15,7 @@ return [
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '12.3.1',
+    'version' => '12.3.2',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
     'requires' => [

--- a/models/classes/QtiResultsService.php
+++ b/models/classes/QtiResultsService.php
@@ -148,6 +148,9 @@ class QtiResultsService extends ConfigurableService implements ResultService
         if (\common_Utils::isUri($userId)) {
             $userId = \tao_helpers_Uri::getUniqueId($userId);
         }
+        if ($userId === false) {
+            $userId = '';
+        }
         $contextElt->setAttribute('sourcedId', $userId);
         $assessmentResultElt->appendChild($contextElt);
 


### PR DESCRIPTION
Related to ticket:
https://oat-sa.atlassian.net/browse/RE-55

The error: 
Fatal error: Uncaught TypeError: DOMElement: :setAttribute() expects parameter 2 to be string, boolean given

How to reproduce:
call https://localhost/taoResultServer/QtiRestResults/getQtiResultXml?delivery=URI&result=URI