### PR TITLE
Fix/re 55 return 404 when delivery execution not found

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -15,7 +15,7 @@ return [
     'label' => 'Result core extension',
     'description' => 'Results Server management and exposed interfaces for results data submission',
     'license' => 'GPL-2.0',
-    'version' => '12.3.2',
+    'version' => '12.3.3',
     'author' => 'Open Assessment Technologies',
     //taoResults may be needed for the taoResults taoResultServerModel that uses taoResults db storage
     'requires' => [

--- a/models/classes/QtiResultsService.php
+++ b/models/classes/QtiResultsService.php
@@ -27,6 +27,7 @@ use common_Exception;
 use common_exception_InvalidArgumentType;
 use common_exception_NotFound;
 use common_exception_NotImplemented;
+use common_exception_ResourceNotFound;
 use core_kernel_classes_Resource;
 use DOMDocument;
 use DOMElement;
@@ -145,12 +146,15 @@ class QtiResultsService extends ConfigurableService implements ResultService
         /** Context */
         $contextElt = $dom->createElementNS(self::QTI_NS, 'context');
         $userId = $resultServer->getTestTaker($deId);
+
+        if ($userId === false) {
+            throw new common_exception_ResourceNotFound('Provided parameters don\'t match with any delivery execution.');
+        }
+
         if (\common_Utils::isUri($userId)) {
             $userId = \tao_helpers_Uri::getUniqueId($userId);
         }
-        if ($userId === false) {
-            $userId = '';
-        }
+
         $contextElt->setAttribute('sourcedId', $userId);
         $assessmentResultElt->appendChild($contextElt);
 


### PR DESCRIPTION
Related to ticket:
https://oat-sa.atlassian.net/browse/RE-55

Related PR: https://github.com/oat-sa/extension-tao-outcome/pull/212

Original Issue:
When input parameters on `taoResultServer/QtiRestResults/getQtiResultXml` endpoint don't identify a delivery execution
we throw a fatal error and eventually 500 HTTP response status code.

Fix:
When input parameter on `taoResultServer/QtiRestResults/getQtiResultXml` endpoint don't identify a delivery execution
then we catch this and throw proper execution to return 404 NOT FOUND response status code.

How to test:

1.simulate prod: set php fpm conf `display_errors` to 0
2.run a delivery execution via LTI and set proper lis_result_sourcedid
3. get results using `taoResultServer/QtiRestResults/getQtiResultXml` endpoint

Before fix:
when proper input parameters are setup - then correct behavior, xml file return
when not proper input parameters are setup - then empty xml results file is returned

After fix:
when proper input parameters are setup - then correct behavior, xml file return
when not proper input parameters are setup - then 404 HTTP response is return with body

```
{
    "success": false,
    "errorCode": 0,
    "errorMsg": "Provided parameters don't match with any delivery execution.",
    "version": "3.4.0-sprint141"
}
```

*NOTE: `lis_result_sourcedid` MUST be unique, and is case-sensitive.  