### PR TITLE
Fix: delete control characters from resulting XML as SimpleXML doesn't support them 

### DIFF
--- a/actions/class.QtiRestResults.php
+++ b/actions/class.QtiRestResults.php
@@ -158,6 +158,8 @@ class taoResultServer_actions_QtiRestResults extends tao_actions_RestController
             throw new common_exception_NotFound('Delivery execution not found.');
         }
 
+        // delete control characters
+        $data = preg_replace('/[\x00-\x1F\x7F]/', '', $data);
         $doc = @simplexml_load_string($data);
         if (!$doc) {
             common_Logger::i('invalid xml result');


### PR DESCRIPTION
Related to ticket:
https://oat-sa.atlassian.net/browse/RE-289

Misbehaviour:
simplexml_load_string encounters control characters and fails.

Fix: XML is sanitized