### PR TITLE
Missing dependency, breaking unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
 		"oat-sa/generis" : ">=14.0.0",
 		"oat-sa/tao-core" : ">=47.0.0",
-		"oat-sa/lib-tao-dtms" : "1.0.0"
+		"oat-sa/lib-tao-dtms" : "1.0.0",
+		"oat-sa/extension-tao-delivery": ">=13.1.0"
 	},
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
Add missing dependency used in `\oat\taoResultServer\models\classes\ResultManagement`. 