### PR TITLE
AUT-1483 - add resolving assessment result file responses into `injectXmltToDeliveryExecution` 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
 		"oat-sa/generis" : ">=15.3.0",
 		"oat-sa/tao-core" : ">=47.0.0",
 		"oat-sa/lib-tao-dtms" : "1.0.0",
-		"qtism/qtism": ">=0.25.2"
+		"qtism/qtism": ">=0.25.0"
 	},
     "autoload" : {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -55,13 +55,20 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-		"oat-sa/generis" : ">=14.0.0",
+		"oat-sa/generis" : ">=15.3.0",
 		"oat-sa/tao-core" : ">=47.0.0",
-		"oat-sa/lib-tao-dtms" : "1.0.0"
+		"oat-sa/lib-tao-dtms" : "1.0.0",
+		"qtism/qtism": ">=0.25.2"
 	},
     "autoload" : {
         "psr-4" : {
             "oat\\taoResultServer\\" : ""
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "oat-sa/oatbox-extension-installer": true,
+            "oat-sa/composer-npm-bridge": true
         }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -6,6 +6,7 @@
  *
  */
 
+use oat\taoResultServer\models\AssessmentResultResolver\DependencyInjection\AssessmentResultResolverContainerServiceProvider;
 use oat\taoResultServer\scripts\update\Updater;
 
 $extpath = __DIR__ . DIRECTORY_SEPARATOR;
@@ -51,5 +52,8 @@ return [
 
         #BASE URL (usually the domain root)
         'BASE_URL'              => ROOT_URL . '/taoResultServer',
+    ],
+    'containerServiceProviders' => [
+        AssessmentResultResolverContainerServiceProvider::class
     ]
 ];

--- a/models/AssessmentResultResolver/AssessmentResultFileResponseResolver.php
+++ b/models/AssessmentResultResolver/AssessmentResultFileResponseResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace oat\taoResultServer\models\AssessmentResultResolver;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use InvalidArgumentException;
+use qtism\common\enums\BaseType;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\ItemResult;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\state\Value;
+use qtism\data\storage\xml\XmlResultDocument;
+use qtism\data\storage\xml\XmlStorageException;
+use tao_helpers_File;
+
+class AssessmentResultFileResponseResolver
+{
+    private const PATTERN = '/^(?<fileName>[^,]+).*download_url,(?<downloadUrl>[^,]+)/';
+    private const FILENAME_KEY = 'fileName';
+    private const DOWNLOAD_URL_KEY = 'downloadUrl';
+
+    /** @var ClientInterface */
+    private $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    public function resolve(AssessmentResult $assessmentResult): AssessmentResult
+    {
+        /** @var ItemResult $itemResult */
+        foreach ($assessmentResult->getItemResults() as $itemResult) {
+            foreach ($itemResult->getItemVariables() as $itemVariable) {
+                if (
+                    $itemVariable instanceof ResultResponseVariable &&
+                    $itemVariable->getBaseType() === BaseType::FILE
+                ) {
+                    /** @var Value $value */
+                    foreach ($itemVariable->getCandidateResponse()->getValues() as $value) {
+                        $value->setValue($this->resolveFileString($value->getValue()));
+                    }
+                }
+            }
+        }
+
+        return $assessmentResult;
+    }
+
+    /**
+     * @throws XmlStorageException
+     */
+    private function convertXmlTotAssessmentResul(string $xml): AssessmentResult
+    {
+        $xmlResultDocument = new XmlResultDocument();
+        $xmlResultDocument->loadFromString($xml);
+        $assessmentResult = $xmlResultDocument->getDocumentComponent();
+        if (!$assessmentResult instanceof AssessmentResult) {
+            throw new InvalidArgumentException('Unsupported xml provided');
+        }
+        return $assessmentResult;
+    }
+
+    private function resolveFileString($value)
+    {
+        $matches = [];
+        preg_match(self::PATTERN, $value, $matches);
+        if (!array_key_exists(self::DOWNLOAD_URL_KEY, $matches)) {
+            return $value;
+        }
+        $downloadUrl = $matches[self::DOWNLOAD_URL_KEY];
+        $fileName = $matches[self::FILENAME_KEY];
+        $fileMimeType = tao_helpers_File::getMimeType($fileName);
+
+        try {
+            $response = $this->client->request('GET', $downloadUrl);
+            if ($response->getStatusCode() >= 400) {
+                return $fileName;
+            }
+        } catch (GuzzleException $e) {
+            return $fileName;
+        }
+
+        return $this->encodeFile($fileName, $fileMimeType, $response->getBody()->getContents());
+    }
+
+    private function encodeFile(string $fileName, string $mimeType, string $binaryContent): string
+    {
+        $packedUnsignedShortFileNameLen = pack('S', strlen($fileName));
+        $packedUnsignedShortMimeTypeLen = pack('S', strlen($mimeType));
+
+        return $packedUnsignedShortFileNameLen . $fileName . $packedUnsignedShortMimeTypeLen . $mimeType . $binaryContent;
+    }
+}

--- a/models/AssessmentResultResolver/AssessmentResultFileResponseResolver.php
+++ b/models/AssessmentResultResolver/AssessmentResultFileResponseResolver.php
@@ -16,7 +16,7 @@ use tao_helpers_File;
 
 class AssessmentResultFileResponseResolver
 {
-    private const PATTERN = '/^(?<fileName>[^,]+).*download_url,(?<downloadUrl>[^,]+)/';
+    private const PATTERN = '/^(?<' . self::FILENAME_KEY . '>[^,]+).*download_url,(?<' . self::DOWNLOAD_URL_KEY . '>[^,]+)/';
     private const FILENAME_KEY = 'fileName';
     private const DOWNLOAD_URL_KEY = 'downloadUrl';
 

--- a/models/AssessmentResultResolver/DependencyInjection/AssessmentResultResolverContainerServiceProvider.php
+++ b/models/AssessmentResultResolver/DependencyInjection/AssessmentResultResolverContainerServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace oat\taoResultServer\models\AssessmentResultResolver\DependencyInjection;
+
+use GuzzleHttp\Client;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\taoResultServer\models\AssessmentResultResolver\AssessmentResultFileResponseResolver;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
+
+class AssessmentResultResolverContainerServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services->set(AssessmentResultFileResponseResolver::class, AssessmentResultFileResponseResolver::class)
+            ->public()
+            ->args([
+                inline_service(Client::class)
+            ]);
+    }
+}

--- a/test/Unit/models/AssessmentResultResolver/AssessmentResultFileResponseResolverTest.php
+++ b/test/Unit/models/AssessmentResultResolver/AssessmentResultFileResponseResolverTest.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoResultServer\test\Unit\models\AssessmentResultResolver;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use oat\dtms\DateTime;
+use oat\taoResultServer\models\AssessmentResultResolver\AssessmentResultFileResponseResolver;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use qtism\common\datatypes\QtiIdentifier;
+use qtism\common\enums\BaseType;
+use qtism\common\enums\Cardinality;
+use qtism\data\results\AssessmentResult;
+use qtism\data\results\CandidateResponse;
+use qtism\data\results\Context;
+use qtism\data\results\ItemResult;
+use qtism\data\results\ItemResultCollection;
+use qtism\data\results\ItemVariableCollection;
+use qtism\data\results\ResultResponseVariable;
+use qtism\data\results\SessionStatus;
+use qtism\data\state\Value;
+use qtism\data\state\ValueCollection;
+use Ramsey\Uuid\Uuid;
+use tao_helpers_File;
+
+class AssessmentResultFileResponseResolverTest extends TestCase
+{
+    private const FILE_DOWNLOAD_URL = 'https://localhost/file/download';
+    private const FILE_NAME = 'filename';
+
+    /** @var AssessmentResultFileResponseResolver */
+    private $subject;
+    /** @var ClientInterface */
+    private $clientMock;
+
+    public function setUp(): void
+    {
+        $this->clientMock = $this->createMock(ClientInterface::class);
+        $this->subject = new AssessmentResultFileResponseResolver($this->clientMock);
+    }
+
+    public function testSuccessResolveFullPossibleFileResponseChangedResponse()
+    {
+        [$filename, $mimeType, $fileContent] = $this->buildFileData();
+
+        $streamResponseMock = $this->createMock(StreamInterface::class);
+        $streamResponseMock->expects(self::once())
+            ->method('getContents')
+            ->willReturn($fileContent);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects(self::once())
+            ->method('getBody')
+            ->willReturn($streamResponseMock);
+        $responseMock->expects(self::once())
+            ->method('getStatusCode')
+            ->willReturn(random_int(200, 399));
+
+        $this->clientMock
+            ->expects(self::once())
+            ->method('request')->willReturn($responseMock);
+
+        $fileResponseValue = new Value(sprintf(
+            '%s,%s,base64,%s,download_url,https://localhost/file/download',
+            $filename,
+            $mimeType,
+            base64_encode($fileContent)
+        ));
+
+        $this->subject->resolve($this->buildAssessmentResult($fileResponseValue));
+
+        self::assertEquals(
+            $this->encodeFile($filename, $mimeType, $fileContent),
+            $fileResponseValue->getValue()
+        );
+    }
+
+    public function testSuccessResolveMinimalPossibleFileResponseChangedResponse()
+    {
+        [$filename, $mimeType, $fileContent] = $this->buildFileData();
+
+        $streamResponseMock = $this->createMock(StreamInterface::class);
+        $streamResponseMock->expects(self::once())
+            ->method('getContents')
+            ->willReturn($fileContent);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects(self::once())
+            ->method('getBody')
+            ->willReturn($streamResponseMock);
+        $responseMock->expects(self::once())
+            ->method('getStatusCode')
+            ->willReturn(random_int(200, 399));
+
+        $this->clientMock
+            ->expects(self::once())
+            ->method('request')->willReturn($responseMock);
+
+        $fileResponseValue = new Value(sprintf('%s,download_url,https://localhost/file/download', $filename));
+
+        $this->subject->resolve($this->buildAssessmentResult($fileResponseValue));
+
+        self::assertEquals(
+            $this->encodeFile($filename, $mimeType, $fileContent),
+            $fileResponseValue->getValue()
+        );
+    }
+
+    private function testResolveWithoutDownloadUrl()
+    {
+        $randomValue = Uuid::uuid4()->toString();
+        $fileResponseValue = new Value($randomValue);
+
+        $this->subject->resolve($this->buildAssessmentResult($fileResponseValue));
+
+        self::assertEquals(
+            $randomValue,
+            $fileResponseValue->getValue()
+        );
+    }
+
+    private function testResolveWithErrorResponseStatusCode()
+    {
+        [$filename, $mimeType, $fileContent] = $this->buildFileData();
+        $responseValueContent = sprintf(
+            '%s,%s,base64,%s,download_url,https://localhost/file/download',
+            $filename,
+            $mimeType,
+            base64_encode($fileContent)
+        );
+
+        $streamResponseMock = $this->createMock(StreamInterface::class);
+        $streamResponseMock->expects(self::once())
+            ->method('getContents')
+            ->willReturn($fileContent);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects(self::once())
+            ->method('getBody')
+            ->willReturn($streamResponseMock);
+        $responseMock->expects(self::once())
+            ->method('getStatusCode')
+            ->willReturn(random_int(400, 599));
+
+        $this->clientMock
+            ->expects(self::once())
+            ->method('request')->willReturn($responseMock);
+
+        $fileResponseValue = new Value($responseValueContent);
+
+        $this->subject->resolve($this->buildAssessmentResult($fileResponseValue));
+
+        self::assertEquals(
+            $responseValueContent,
+            $fileResponseValue->getValue()
+        );
+    }
+
+    private function testResolveWithRequestException()
+    {
+        [$filename, $mimeType, $fileContent] = $this->buildFileData();
+        $responseValueContent = sprintf(
+            '%s,%s,base64,%s,download_url,https://localhost/file/download',
+            $filename,
+            $mimeType,
+            base64_encode($fileContent)
+        );
+
+        $streamResponseMock = $this->createMock(StreamInterface::class);
+        $streamResponseMock->expects(self::never())
+            ->method('getContents')
+            ->willReturn($fileContent);
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects(self::never())
+            ->method('getBody')
+            ->willReturn($streamResponseMock);
+        $responseMock->expects(self::never())
+            ->method('getStatusCode');
+
+        $this->clientMock
+            ->expects(self::once())
+            ->method('request')->willThrowException($this->createMock(GuzzleException::class));
+
+        $fileResponseValue = new Value($responseValueContent);
+
+        $this->subject->resolve($this->buildAssessmentResult($fileResponseValue));
+
+        self::assertEquals(
+            $responseValueContent,
+            $fileResponseValue->getValue()
+        );
+    }
+
+    private function buildAssessmentResult(Value $responseValue): AssessmentResult
+    {
+        return new AssessmentResult(
+            new Context(),
+            null,
+            new ItemResultCollection([
+                new ItemResult(
+                    new QtiIdentifier('item'),
+                    new DateTime(),
+                    SessionStatus::STATUS_FINAL,
+                    new ItemVariableCollection([
+                        new ResultResponseVariable(
+                            new QtiIdentifier('RESPONSE'),
+                            Cardinality::SINGLE,
+                            new CandidateResponse(new ValueCollection([
+                                $responseValue
+                            ])),
+                            BaseType::FILE
+                        )
+                    ])
+                )
+            ])
+        );
+    }
+
+    private function getRandomFileExtension(): string
+    {
+        $mimeTypes = tao_helpers_File::getMimeTypeList();
+        return array_rand($mimeTypes);
+    }
+
+    private function encodeFile(string $fileName, string $mimeType, string $binaryContent): string
+    {
+        $packedUnsignedShortFileNameLen = pack('S', strlen($fileName));
+        $packedUnsignedShortMimeTypeLen = pack('S', strlen($mimeType));
+
+        return $packedUnsignedShortFileNameLen . $fileName . $packedUnsignedShortMimeTypeLen . $mimeType . $binaryContent;
+    }
+
+    /**
+     * @return array [$filename,$mimeType,$fileContent]
+     * @throws \Exception
+     */
+    private function buildFileData(): array
+    {
+        $fileContent = Uuid::uuid4()->toString();
+
+        $mimeTypes = tao_helpers_File::getMimeTypeList();
+        $randomExtension = array_rand($mimeTypes);
+        $mimeType = $mimeTypes[$randomExtension];
+
+        $filename = self::FILE_NAME . '.' . $randomExtension;
+
+        return [$filename, $mimeType, $fileContent];
+    }
+}


### PR DESCRIPTION
# [AUT-1483](https://oat-sa.atlassian.net/browse/AUT-1483)

## Summary
Added functionality for resolving assessment result file resolving in `injectXmltToDeliveryExecution` method of `QtiResultsService`

## How to test 
* update backoffice by branch
* configure launching deliver on solar with lti in terre
    *  [Conflence doc](https://oat-sa.atlassian.net/wiki/spaces/~575513335/pages/1667204040/LTI+1.3+-+Deliver+Launch)
    * [Readme from `extension-tao-deliver-connect`](https://github.com/oat-sa/extension-tao-deliver-connect/blob/master/README.md)
* execute delivery with file upload interaction
* result with files should be handled and stored in correct format, file available to download

---
Example of .env
```
FEATURE_FLAG_LTI1P3=true
DELIVERTENANT_COUNT=1
DELIVERTENANT_0_ID=1
DELIVERTENANT_0_LABEL="Customer 1 - Deliver - LTI 1.3 - .env"
DELIVERTENANT_0_CUSTOMER_ID=1
DELIVERTENANT_0_ROOT_URL=http://deliver.docker.localhost/api/v1/
DELIVERTENANT_0_OAUTH_CREDENTIALS_COUNT=1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_KEY=bbb1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_SECRET=bbb1
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_0=Learner
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_1=ContentDeveloper
DELIVERTENANT_0_OAUTH_CREDENTIALS_0_ROLES_COUNT=2
DELIVERTENANT_0_LTI_CREDENTIALS_0_KEY=aaa1
DELIVERTENANT_0_LTI_CREDENTIALS_0_SECRET=aaa1
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_COUNT=2
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_0=Learner
DELIVERTENANT_0_LTI_CREDENTIALS_0_ROLES_1=ContentDeveloper
DELIVERTENANT_0_LTI_CREDENTIALS_COUNT=1
```
## TAE
https://oat-sa.atlassian.net/browse/AUT-1483?focusedCommentId=181364