### PR TITLE
fix: remove cyclic dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
 	},
 	"require": {
 		"oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-		"oat-sa/extension-tao-delivery": ">=15.10.0",
 		"oat-sa/generis" : ">=15.22",
 		"oat-sa/tao-core" : ">=50.24.6",
 		"oat-sa/lib-tao-dtms" : "^1.0.1",
@@ -71,5 +70,8 @@
 			"oat-sa/oatbox-extension-installer": true,
 			"oat-sa/composer-npm-bridge": true
 		}
+	},
+	"require-dev": {
+		"oat-sa/extension-tao-delivery": ">=15.10.0"
 	}
 }


### PR DESCRIPTION
Remove cyclic dependency

Error:

```
**Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /var/www/html/taoResultServer/manifest.php on line 15

Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in /var/www/html/generis/common/class.Logger.php on line 461

Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes) in Unknown on line 0**
```