### PR TITLE
Feature/tr 4956/api to send ags scores on demand

### DIFF
--- a/controller/DeliveryExecutionResults.php
+++ b/controller/DeliveryExecutionResults.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoResultServer\controller;
+
+use http\Exception\BadQueryStringException;
+use oat\oatbox\event\EventManagerAwareTrait;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
+use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
+use oat\taoOutcomeUi\model\ResultsService;
+use oat\taoOutcomeUi\model\Wrapper\ResultServiceWrapper;
+use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
+use tao_actions_RestController;
+use taoResultServer_models_classes_OutcomeVariable;
+
+class DeliveryExecutionResults extends tao_actions_RestController
+{
+    use EventManagerAwareTrait;
+
+    private const Q_PARAM_DELIVERY_EXECUTION_ID = 'execution';
+    private const Q_PARAM_TRIGGER_AGS_SEND = 'send_ags';
+
+    public function patch(DeliveryExecutionService $deliveryExecutionService): void
+    {
+        $queryParams = $this->getPsrRequest()->getQueryParams();
+        $this->validateRequestParams($queryParams);
+
+        $deliveryExecution = $deliveryExecutionService->getDeliveryExecution(
+            $queryParams[self::Q_PARAM_DELIVERY_EXECUTION_ID]
+        );
+
+        // Todo patch variables pending in scope of TR-4952
+
+        if (isset($queryParams[self::Q_PARAM_TRIGGER_AGS_SEND])) {
+            $this->triggerAgsResultSend($deliveryExecution);
+        }
+    }
+
+    private function validateRequestParams(array $queryParams): void
+    {
+        if (!isset($queryParams[self::Q_PARAM_DELIVERY_EXECUTION_ID])) {
+            throw new BadQueryStringException(
+                sprintf('Missing %s query', self::Q_PARAM_DELIVERY_EXECUTION_ID)
+            );
+        };
+    }
+
+    private function triggerAgsResultSend(DeliveryExecutionInterface $deliveryExecution): void
+    {
+        $variables = $this->getResultsService()->getVariables(
+            $deliveryExecution->getIdentifier(),
+        );
+        $testLevelVariables = $this->getResultsService()->extractTestVariables(
+            $variables,
+            [taoResultServer_models_classes_OutcomeVariable::class],
+            ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+        );
+
+        $scoreTotal = null;
+        $scoreTotalMax = null;
+
+        foreach ($testLevelVariables as $variable) {
+            if ($variable->getIdentifier() === 'SCORE_TOTAL') {
+                $scoreTotal = $variable->getValue();
+            }
+
+            if ($variable->getIdentifier() === 'SCORE_TOTAL_MAX') {
+                $scoreTotalMax = $variable->getValue();
+            }
+
+            if ($scoreTotal !== null && $scoreTotalMax !== null) {
+                break;
+            }
+        }
+
+        $this->getEventManager()->trigger(
+            new DeliveryExecutionResultsRecalculated($deliveryExecution, $scoreTotal, $scoreTotalMax)
+        );
+    }
+
+    private function getResultsService(): ResultsService
+    {
+        $implementation = $this->getServiceLocator()->get(AbstractRdsResultStorage::SERVICE_ID);
+        $resultService = $this->getServiceLocator()->get(ResultServiceWrapper::SERVICE_ID)->getService();
+        $resultService->setImplementation($implementation);
+
+        return $resultService;
+    }
+}

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -72,8 +72,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
         );
         $testLevelVariables = $this->getResultsService()->extractTestVariables(
             $variables,
-            [taoResultServer_models_classes_OutcomeVariable::class],
-            ResultsService::VARIABLES_FILTER_LAST_SUBMITTED
+            [taoResultServer_models_classes_OutcomeVariable::class]
         );
 
         $scoreTotal = null;
@@ -94,7 +93,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
         }
 
         $this->getEventManager()->trigger(
-            new DeliveryExecutionResultsRecalculated($deliveryExecution, $scoreTotal, $scoreTotalMax)
+            new DeliveryExecutionResultsRecalculated($deliveryExecution, (float)$scoreTotal, (float)$scoreTotalMax)
         );
     }
 

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -58,13 +58,16 @@ class DeliveryExecutionResults extends tao_actions_RestController
         );
 
         if (!$deliveryExecution->getFinishTime()) {
-            $this->setErrorJsonResponse("Delivery execution not found");
+            $this->setErrorJsonResponse("Finished delivery execution not found", 0, [], 404);
             return;
         }
 
         // Todo patch variables pending in scope of the next phase of development
 
-        if (isset($queryParams[self::Q_PARAM_TRIGGER_AGS_SEND])) {
+        if (
+            isset($queryParams[self::Q_PARAM_TRIGGER_AGS_SEND]) &&
+            $queryParams[self::Q_PARAM_TRIGGER_AGS_SEND] !== 'false'
+        ) {
             $this->triggerAgsResultSend($deliveryExecution);
             $agsNotificationTriggered = true;
         }
@@ -88,12 +91,12 @@ class DeliveryExecutionResults extends tao_actions_RestController
 
         foreach ($variableObjects as $variable) {
             if ($variable->getIdentifier() === 'SCORE_TOTAL') {
-                $scoreTotal = $variable->getValue();
+                $scoreTotal = (float)$variable->getValue();
                 continue;
             }
 
             if ($variable->getIdentifier() === 'SCORE_TOTAL_MAX') {
-                $scoreTotalMax = $variable->getValue();
+                $scoreTotalMax = (float)$variable->getValue();
                 continue;
             }
 
@@ -103,7 +106,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
         }
 
         $this->getEventManager()->trigger(
-            new DeliveryExecutionResultsRecalculated($deliveryExecution, (float)$scoreTotal, (float)$scoreTotalMax)
+            new DeliveryExecutionResultsRecalculated($deliveryExecution, $scoreTotal, $scoreTotalMax)
         );
     }
 

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -49,7 +49,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
             $queryParams[self::Q_PARAM_DELIVERY_EXECUTION_ID]
         );
 
-        // Todo patch variables pending in scope of TR-4952
+        // Todo patch variables pending in scope of the next phase of development
 
         if (isset($queryParams[self::Q_PARAM_TRIGGER_AGS_SEND])) {
             $this->triggerAgsResultSend($deliveryExecution);
@@ -81,10 +81,12 @@ class DeliveryExecutionResults extends tao_actions_RestController
         foreach ($testLevelVariables as $variable) {
             if ($variable->getIdentifier() === 'SCORE_TOTAL') {
                 $scoreTotal = $variable->getValue();
+                continue;
             }
 
             if ($variable->getIdentifier() === 'SCORE_TOTAL_MAX') {
                 $scoreTotalMax = $variable->getValue();
+                continue;
             }
 
             if ($scoreTotal !== null && $scoreTotalMax !== null) {

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -44,10 +44,11 @@ class DeliveryExecutionResults extends tao_actions_RestController
     public function patch(DeliveryExecutionService $deliveryExecutionService): void
     {
         $queryParams = $this->getPsrRequest()->getQueryParams();
+        $agsNotificationTriggered = false;
 
         if (!isset($queryParams[self::Q_PARAM_DELIVERY_EXECUTION_ID])) {
             $this->setErrorJsonResponse(
-                sprintf('Missing %s query', self::Q_PARAM_DELIVERY_EXECUTION_ID)
+                sprintf('Missing %s query param', self::Q_PARAM_DELIVERY_EXECUTION_ID)
             );
             return;
         };
@@ -65,11 +66,12 @@ class DeliveryExecutionResults extends tao_actions_RestController
 
         if (isset($queryParams[self::Q_PARAM_TRIGGER_AGS_SEND])) {
             $this->triggerAgsResultSend($deliveryExecution);
+            $agsNotificationTriggered = true;
         }
-    }
 
-    private function validateRequestParams(array $queryParams): void
-    {
+        $this->setSuccessJsonResponse([
+            'agsNotificationTriggered' => $agsNotificationTriggered
+        ]);
     }
 
     private function triggerAgsResultSend(DeliveryExecutionInterface $deliveryExecution): void

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoResultServer\controller\rest;
 
+use common_exception_Error;
 use oat\oatbox\event\EventManagerAwareTrait;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\oatbox\service\ServiceNotFoundException;
@@ -111,7 +112,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
     }
 
     /**
-     * @throws \common_exception_Error
+     * @throws common_exception_Error
      * @throws InvalidServiceManagerException
      * @throws ServiceNotFoundException
      */
@@ -123,7 +124,7 @@ class DeliveryExecutionResults extends tao_actions_RestController
         $storage = $resultService->getResultStorage();
 
         if (!$storage instanceof ReadableResultStorage) {
-            throw new \common_exception_Error('Configured result storage is not writable.');
+            throw new common_exception_Error('Configured result storage is not writable.');
         }
 
         return $storage;

--- a/controller/rest/DeliveryExecutionResults.php
+++ b/controller/rest/DeliveryExecutionResults.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace oat\taoResultServer\controller;
+namespace oat\taoResultServer\controller\rest;
 
 use http\Exception\BadQueryStringException;
 use oat\oatbox\event\EventManagerAwareTrait;

--- a/manifest.php
+++ b/manifest.php
@@ -6,7 +6,10 @@
  *
  */
 
-use oat\taoResultServer\models\AssessmentResultResolver\DependencyInjection\AssessmentResultResolverContainerServiceProvider;
+use oat\tao\model\routing\LegacyRoute;
+use oat\taoResultServer\models\AssessmentResultResolver
+\DependencyInjection\AssessmentResultResolverContainerServiceProvider;
+use oat\taoResultServer\models\routing\ApiRoute;
 use oat\taoResultServer\scripts\update\Updater;
 
 $extpath = __DIR__ . DIRECTORY_SEPARATOR;
@@ -32,7 +35,9 @@ return [
     'managementRole' => 'http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultServerRole',
     'acl' => [
         ['grant', 'http://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultServerRole', ['ext' => 'taoResultServer']],
-        ['grant', 'http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole', ['ext' => 'taoResultServer', 'mod' => 'ResultServerStateFull']],
+        ['grant', 'http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole', [
+            'ext' => 'taoResultServer', 'mod' => 'ResultServerStateFull'
+        ]],
     ],
     'constants' => [
         # actions directory
@@ -54,7 +59,9 @@ return [
         'BASE_URL'              => ROOT_URL . '/taoResultServer',
     ],
     'routes' => [
-        '/taoResultServer' => 'oat\\taoResultServer\\actions'
+       '/taoResultServer/api' => ['class' => ApiRoute::class],
+       '/taoResultServer' => ['class' => LegacyRoute::class],
+
     ],
     'containerServiceProviders' => [
         AssessmentResultResolverContainerServiceProvider::class

--- a/manifest.php
+++ b/manifest.php
@@ -53,6 +53,9 @@ return [
         #BASE URL (usually the domain root)
         'BASE_URL'              => ROOT_URL . '/taoResultServer',
     ],
+    'routes' => [
+        '/taoResultServer' => 'oat\\taoResultServer\\actions'
+    ],
     'containerServiceProviders' => [
         AssessmentResultResolverContainerServiceProvider::class
     ]

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace oat\taoResultServer\models\Events;
+
+use oat\oatbox\event\Event;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+
+class DeliveryExecutionResultsRecalculated implements Event
+{
+    private DeliveryExecutionInterface $deliveryExecution;
+    private ?float $totalScore;
+    private ?float $totalMaxScore;
+
+    public function __construct(DeliveryExecutionInterface $deliveryExecution, ?float $totalScore, ?float $totalMaxScore)
+    {
+        $this->deliveryExecution = $deliveryExecution;
+        $this->totalScore = $totalScore;
+        $this->totalMaxScore = $totalMaxScore;
+    }
+
+    public function getDeliveryExecution(): DeliveryExecutionInterface
+    {
+        return $this->deliveryExecution;
+    }
+
+    public function getName(): string
+    {
+        return __CLASS__;
+    }
+
+    public function getScore(): ?float
+    {
+        return $this->totalScore;
+    }
+
+    public function getMaxScore(): ?float
+    {
+        return $this->totalMaxScore;
+    }
+}

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -52,12 +52,12 @@ class DeliveryExecutionResultsRecalculated implements Event
         return self::class;
     }
 
-    public function getScore(): ?float
+    public function getTotalScore(): ?float
     {
         return $this->totalScore;
     }
 
-    public function getMaxScore(): ?float
+    public function getTotalMaxScore(): ?float
     {
         return $this->totalMaxScore;
     }

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -1,5 +1,26 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
 namespace oat\taoResultServer\models\Events;
 
 use oat\oatbox\event\Event;
@@ -28,7 +49,7 @@ class DeliveryExecutionResultsRecalculated implements Event
 
     public function getName(): string
     {
-        return __CLASS__;
+        return self::class;
     }
 
     public function getScore(): ?float

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -11,8 +11,11 @@ class DeliveryExecutionResultsRecalculated implements Event
     private ?float $totalScore;
     private ?float $totalMaxScore;
 
-    public function __construct(DeliveryExecutionInterface $deliveryExecution, ?float $totalScore, ?float $totalMaxScore)
-    {
+    public function __construct(
+        DeliveryExecutionInterface $deliveryExecution,
+        ?float $totalScore,
+        ?float $totalMaxScore
+    ) {
         $this->deliveryExecution = $deliveryExecution;
         $this->totalScore = $totalScore;
         $this->totalMaxScore = $totalMaxScore;

--- a/models/routing/ApiRoute.php
+++ b/models/routing/ApiRoute.php
@@ -18,6 +18,8 @@
  * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
  */
 
+declare(strict_types=1);
+
 namespace oat\taoResultServer\models\routing;
 
 use oat\tao\model\routing\AbstractApiRoute;

--- a/models/routing/ApiRoute.php
+++ b/models/routing/ApiRoute.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoResultServer\models\routing;
+
+use oat\tao\model\routing\AbstractApiRoute;
+
+final class ApiRoute extends AbstractApiRoute
+{
+    private const REST_CONTROLLER_PREFIX = 'oat\\taoResultServer\\controller\\rest\\';
+
+    /**
+     * @inheritdoc
+     */
+    public static function getControllerPrefix()
+    {
+        return self::REST_CONTROLLER_PREFIX;
+    }
+}

--- a/models/routing/ApiRoute.php
+++ b/models/routing/ApiRoute.php
@@ -29,8 +29,20 @@ final class ApiRoute extends AbstractApiRoute
     /**
      * @inheritdoc
      */
-    public static function getControllerPrefix()
+    public static function getControllerPrefix(): string
     {
         return self::REST_CONTROLLER_PREFIX;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAction($method): string
+    {
+        if ($method == 'PATCH') {
+            return 'patch';
+        }
+
+        return parent::getAction($method);
     }
 }


### PR DESCRIPTION
Related ticket: https://oat-sa.atlassian.net/browse/TR-4956
Added API method to trigger sending AGS notification for a delivery execution on demand.
Dependencies:
- https://github.com/oat-sa/extension-tao-lti/pull/361
- https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/329