### PR TITLE
[FIX] [INF-187] introduce missing flag isExternallyGraded on itemVariables

### DIFF
--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -180,6 +180,7 @@ class ResultImporter
                 $scoreTotal += $outcomeValue;
 
                 $variable->setValue($outcomeValue);
+                $variable->setExternallyGraded(true);
 
                 $updateOutcomeVariables[$variableId] = $variable;
 

--- a/models/classes/class.Variable.php
+++ b/models/classes/class.Variable.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
  * test at all. For example, items that are organized with learning resources and presented
  * individually in a formative context.
  */
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace,Squiz.Classes.ValidClassName.NotCamelCaps
 abstract class taoResultServer_models_classes_Variable implements JsonSerializable
 {
     public const CARDINALITY_SINGLE = 'single';
@@ -90,12 +92,17 @@ abstract class taoResultServer_models_classes_Variable implements JsonSerializab
      */
     public function setCardinality($cardinality = self::CARDINALITY_SINGLE): self
     {
-        if (!in_array($cardinality, [
-            self::CARDINALITY_SINGLE,
-            self::CARDINALITY_MULTIPLE,
-            self::CARDINALITY_ORDERED,
-            self::CARDINALITY_RECORD,
-        ], true)
+        if (
+            !in_array(
+                $cardinality,
+                [
+                    self::CARDINALITY_SINGLE,
+                    self::CARDINALITY_MULTIPLE,
+                    self::CARDINALITY_ORDERED,
+                    self::CARDINALITY_RECORD,
+                ],
+                true
+            )
         ) {
             throw new common_exception_InvalidArgumentType('cardinality');
         }

--- a/models/classes/class.Variable.php
+++ b/models/classes/class.Variable.php
@@ -69,6 +69,8 @@ abstract class taoResultServer_models_classes_Variable implements JsonSerializab
      */
     protected $epoch;
 
+    private bool $isExternallyGraded = false;
+
     abstract protected function getType(): string;
 
     public function setIdentifier(string $identifier): self
@@ -256,5 +258,17 @@ abstract class taoResultServer_models_classes_Variable implements JsonSerializab
         self::validateKeys(['trace'], $rawTraceVariable);
 
         return (new taoResultServer_models_classes_TraceVariable())->setTrace($rawTraceVariable['trace']);
+    }
+
+    public function setExternallyGraded(bool $flag): self
+    {
+        $this->isExternallyGraded = $flag;
+
+        return $this;
+    }
+
+    public function getExternallyGraded(): bool
+    {
+        return $this->isExternallyGraded;
     }
 }

--- a/models/classes/class.Variable.php
+++ b/models/classes/class.Variable.php
@@ -194,6 +194,7 @@ abstract class taoResultServer_models_classes_Variable implements JsonSerializab
             'baseType' => $this->baseType,
             'epoch' => $this->epoch,
             'type' => $this->getType(),
+            'externallyGraded' => $this->getExternallyGraded(),
         ];
     }
 
@@ -247,7 +248,8 @@ abstract class taoResultServer_models_classes_Variable implements JsonSerializab
         return (new taoResultServer_models_classes_OutcomeVariable())
             ->setNormalMinimum($rawOutcomeVariable['normalMinimum'])
             ->setNormalMaximum($rawOutcomeVariable['normalMaximum'])
-            ->setEncodedValue($rawOutcomeVariable['value']);
+            ->setEncodedValue($rawOutcomeVariable['value'])
+            ->setExternallyGraded($rawOutcomeVariable['externallyGraded'] ?? false);
     }
 
     private static function fromResponseVariableData(

--- a/test/Unit/models/Import/Service/ResultImporterTest.php
+++ b/test/Unit/models/Import/Service/ResultImporterTest.php
@@ -397,6 +397,7 @@ class ResultImporterTest extends TestCase
         $variable->setIdentifier('SCORE');
         $variable->setCardinality('single');
         $variable->setBaseType('float');
+        $variable->setExternallyGraded(true);
 
         return $variable;
     }

--- a/test/Unit/models/Mapper/ResultMapperTest.php
+++ b/test/Unit/models/Mapper/ResultMapperTest.php
@@ -22,10 +22,10 @@
 namespace oat\taoResultServer\test\Unit\models\Mapper;
 
 use oat\dtms\DateTime;
-use oat\generis\test\TestCase;
-use oat\oatbox\log\LoggerService;
+use oat\generis\test\ServiceManagerMockTrait;
 use oat\taoResultServer\models\Mapper\ResultMapper;
-use Psr\Log\NullLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use qtism\data\results\AssessmentResult;
 use qtism\data\storage\xml\XmlResultDocument;
 use taoResultServer_models_classes_ResponseVariable;
@@ -40,7 +40,9 @@ class ResultMapperTest extends TestCase
         $doc = new XmlResultDocument();
         $doc->loadFromString(file_get_contents($file));
         $resultMapper = new ResultMapper();
-        $resultMapper->setServiceLocator($this->getServiceLocatorMock([LoggerService::SERVICE_ID => new NullLogger()]));
+        $resultMapper->setLogger(
+            $this->createMock(LoggerInterface::class)
+        );
         return $resultMapper->loadSource($doc->getDocumentComponent());
     }
 

--- a/test/Unit/models/Mapper/ResultMapperTest.php
+++ b/test/Unit/models/Mapper/ResultMapperTest.php
@@ -96,7 +96,10 @@ class ResultMapperTest extends TestCase
         $variable = reset($variables);
         $this->assertInstanceOf(taoResultServer_models_classes_ResponseVariable::class, $variable);
         $this->assertEquals('response-identifier', $variable->getIdentifier());
-        $this->assertEquals('fixture-test-value3;fixture-test-value4;fixture-test-value5', $variable->getCandidateResponse());
+        $this->assertEquals(
+            'fixture-test-value3;fixture-test-value4;fixture-test-value5',
+            $variable->getCandidateResponse()
+        );
         $this->assertEquals('fixture-test-value3;fixture-test-value4;fixture-test-value5', $variable->getValue());
         $this->assertEquals('fixture-test-value1;fixture-test-value2', $variable->getCorrectResponse());
         $this->assertEquals('single', $variable->getCardinality());

--- a/test/Unit/models/classes/class.OutcomeVariableTest.php
+++ b/test/Unit/models/classes/class.OutcomeVariableTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
  */
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace,Squiz.Classes.ValidClassName.NotCamelCaps
 class taoResultServer_models_classes_OutcomeVariableTest extends TestCase
 {
     public function testVariableCanBeJsonSerialized(): void
@@ -43,7 +44,7 @@ class taoResultServer_models_classes_OutcomeVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_OutcomeVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'normalMinimum' => 1.00,
             'normalMaximum' => 10.00,
             'value' => base64_encode('testValue'),

--- a/test/Unit/models/classes/class.OutcomeVariableTest.php
+++ b/test/Unit/models/classes/class.OutcomeVariableTest.php
@@ -43,6 +43,7 @@ class taoResultServer_models_classes_OutcomeVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_OutcomeVariable::TYPE,
+            'externallyGraded' =>false,
             'normalMinimum' => 1.00,
             'normalMaximum' => 10.00,
             'value' => base64_encode('testValue'),

--- a/test/Unit/models/classes/class.ResponseVariableTest.php
+++ b/test/Unit/models/classes/class.ResponseVariableTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
  */
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace,Squiz.Classes.ValidClassName.NotCamelCaps
 class taoResultServer_models_classes_ResponseVariableTest extends TestCase
 {
     public function testVariableCanBeJsonSerialized(): void
@@ -42,7 +43,7 @@ class taoResultServer_models_classes_ResponseVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_ResponseVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'correctResponse' => 'testCorrectResponse',
             'candidateResponse' => base64_encode('testCandidateResponse'),
         ]), json_encode($subject));

--- a/test/Unit/models/classes/class.ResponseVariableTest.php
+++ b/test/Unit/models/classes/class.ResponseVariableTest.php
@@ -42,6 +42,7 @@ class taoResultServer_models_classes_ResponseVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_ResponseVariable::TYPE,
+            'externallyGraded' =>false,
             'correctResponse' => 'testCorrectResponse',
             'candidateResponse' => base64_encode('testCandidateResponse'),
         ]), json_encode($subject));

--- a/test/Unit/models/classes/class.TraceVariableTest.php
+++ b/test/Unit/models/classes/class.TraceVariableTest.php
@@ -41,6 +41,7 @@ class taoResultServer_models_classes_TraceVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_TraceVariable::TYPE,
+            'externallyGraded' =>false,
             'trace' => 'testTrace',
         ]), json_encode($subject));
     }

--- a/test/Unit/models/classes/class.TraceVariableTest.php
+++ b/test/Unit/models/classes/class.TraceVariableTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
  */
 
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace,Squiz.Classes.ValidClassName.NotCamelCaps
 class taoResultServer_models_classes_TraceVariableTest extends TestCase
 {
     public function testVariableCanBeJsonSerialized(): void
@@ -41,7 +42,7 @@ class taoResultServer_models_classes_TraceVariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_TraceVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'trace' => 'testTrace',
         ]), json_encode($subject));
     }

--- a/test/Unit/models/classes/class.VariableTest.php
+++ b/test/Unit/models/classes/class.VariableTest.php
@@ -23,6 +23,8 @@ use PHPUnit\Framework\TestCase;
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies S.A.
  */
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace,Squiz.Classes.ValidClassName.NotCamelCaps
 class taoResultServer_models_classes_VariableTest extends TestCase
 {
     public function testVariableCanBeJsonSerialized(): void
@@ -54,7 +56,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => 'testType',
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
         ]), json_encode($subject));
     }
 
@@ -93,7 +95,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_OutcomeVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'normalMinimum' => 0.0,
             'normalMaximum' => 10.0,
             'value' => 'testValue',
@@ -123,7 +125,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_ResponseVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'correctResponse' => 'testCorrectResponse',
             'candidateResponse' => 'testCandidateResponse',
         ];
@@ -151,7 +153,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_TraceVariable::TYPE,
-            'externallyGraded' =>false,
+            'externallyGraded' => false,
             'trace' => 'test',
         ];
 

--- a/test/Unit/models/classes/class.VariableTest.php
+++ b/test/Unit/models/classes/class.VariableTest.php
@@ -54,6 +54,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => 'testType',
+            'externallyGraded' =>false,
         ]), json_encode($subject));
     }
 
@@ -92,6 +93,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_OutcomeVariable::TYPE,
+            'externallyGraded' =>false,
             'normalMinimum' => 0.0,
             'normalMaximum' => 10.0,
             'value' => 'testValue',
@@ -121,6 +123,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_ResponseVariable::TYPE,
+            'externallyGraded' =>false,
             'correctResponse' => 'testCorrectResponse',
             'candidateResponse' => 'testCandidateResponse',
         ];
@@ -148,6 +151,7 @@ class taoResultServer_models_classes_VariableTest extends TestCase
             'baseType' => 'testBaseType',
             'epoch' => 'testEpoch',
             'type' => \taoResultServer_models_classes_TraceVariable::TYPE,
+            'externallyGraded' =>false,
             'trace' => 'test',
         ];
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-187

## What's Changed

- Added missing flag is externally graded

## Dependencies PRs

- https://github.com/oat-sa/extension-lti-test-review/pull/121
- https://github.com/oat-sa/extension-tao-outcome/pull/240
- https://github.com/oat-sa/extension-tao-outcomerds/pull/151
- https://github.com/oat-sa/extension-tao-outcomeui/pull/462


## How to test
- Please check https://oat-sa.atlassian.net/browse/INF-187