### PR TITLE
fix: remove check if updated SCORE_TOTAL lower than SCORE_TOTAL_MAX

### DIFF
--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -78,8 +78,7 @@ class ResultImporter
                     $testScoreVariables['scoreTotalVariableId'],
                     $deliveryExecutionUri,
                     $testUri,
-                    $totalScoreCalculatedByItemOutcomes,
-                    $testScoreVariables['scoreTotalMax']
+                    $totalScoreCalculatedByItemOutcomes
                 );
             }
         );
@@ -94,19 +93,8 @@ class ResultImporter
         int $scoreTotalVariableId,
         string $deliveryExecutionUri,
         string $testUri,
-        float $updatedScoreTotal,
-        float $scoreTotalMax
+        float $updatedScoreTotal
     ): void {
-        if (!empty($scoreTotalMax) && $updatedScoreTotal > $scoreTotalMax) {
-            throw new ImportResultException(
-                sprintf(
-                    'SCORE_TOTAL cannot be higher than SCORE_TOTAL_MAX: %s, %s provided',
-                    $scoreTotalMax,
-                    $updatedScoreTotal
-                )
-            );
-        }
-
         $scoreTotalVariable->setValue($updatedScoreTotal);
 
         $resultStorage->replaceTestVariables(

--- a/test/Unit/models/Import/Service/ResultImporterTest.php
+++ b/test/Unit/models/Import/Service/ResultImporterTest.php
@@ -306,7 +306,7 @@ class ResultImporterTest extends TestCase
         $this->sut->importByResultInput($this->input);
     }
 
-    public function testCreateByImportResultWithOverflowMaxScoreWillFail(): void
+    public function testCreateByImportResultWorksWithOverflowMaxScore(): void
     {
         $this->input->addOutcome('item-1', 'SCORE', 1.1);
 
@@ -317,7 +317,7 @@ class ResultImporterTest extends TestCase
                 [
                     777 => [
                         (object)[
-                            'variable' => $this->createTestVariable(1, 'SCORE_TOTAL'),
+                            'variable' => $this->createTestVariable(5, 'SCORE_TOTAL'),
                         ],
                     ],
                     999 => [
@@ -346,9 +346,6 @@ class ResultImporterTest extends TestCase
                     return [];
                 }
             );
-
-        $this->expectException(ImportResultException::class);
-        $this->expectExceptionMessage('SCORE_TOTAL cannot be higher than SCORE_TOTAL_MAX: 1, 1.1 provided');
 
         $this->sut->importByResultInput($this->input);
     }


### PR DESCRIPTION
The PR aim is to fix following issue:
Author is able to make some test items to be not mandatory to answer so that after passing the test sum of max score will be not empty but already lower then total score or total score calculated after update via the API and that was blocking API usage. So we decided to remove that check and the exception.