### PR TITLE
fix: change return timestamp to return last outcome timestamp

### DIFF
--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -32,14 +32,14 @@ class DeliveryExecutionResultsRecalculated implements Event
     private ?float $totalScore;
     private ?float $totalMaxScore;
     private bool $isFullyGraded;
-    private int $timestamp;
+    private ?int $timestamp;
 
     public function __construct(
         DeliveryExecutionInterface $deliveryExecution,
         ?float $totalScore,
         ?float $totalMaxScore,
         bool $isFullyGraded,
-        int $timestamp
+        ?int $timestamp
     ) {
         $this->deliveryExecution = $deliveryExecution;
         $this->totalScore = $totalScore;
@@ -73,7 +73,7 @@ class DeliveryExecutionResultsRecalculated implements Event
         return $this->isFullyGraded;
     }
 
-    public function getTimestamp(): int
+    public function getTimestamp(): ?int
     {
         return $this->timestamp;
     }

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -32,7 +32,7 @@ class DeliveryExecutionResultsRecalculated implements Event
     private ?float $totalScore;
     private ?float $totalMaxScore;
     private bool $isFullyGraded;
-    private ?int $timestamp;
+    private int $timestamp;
 
     public function __construct(
         DeliveryExecutionInterface $deliveryExecution,

--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -39,7 +39,7 @@ class DeliveryExecutionResultsRecalculated implements Event
         ?float $totalScore,
         ?float $totalMaxScore,
         bool $isFullyGraded,
-        ?int $timestamp
+        int $timestamp
     ) {
         $this->deliveryExecution = $deliveryExecution;
         $this->totalScore = $totalScore;
@@ -73,7 +73,7 @@ class DeliveryExecutionResultsRecalculated implements Event
         return $this->isFullyGraded;
     }
 
-    public function getTimestamp(): ?int
+    public function getTimestamp(): int
     {
         return $this->timestamp;
     }

--- a/models/Import/Service/DeliveredTestOutcomeDeclarationsService.php
+++ b/models/Import/Service/DeliveredTestOutcomeDeclarationsService.php
@@ -58,7 +58,6 @@ class DeliveredTestOutcomeDeclarationsService
         foreach ($testDefinition->getTestParts() as $testPart) {
             /** @var ExtendedAssessmentSection $section */
             foreach ($testPart->getAssessmentSections() as $section) {
-                $items = [];
                 /** @var ExtendedAssessmentItemRef $item */
                 foreach ($section->getSectionParts() as $item) {
                     $itemData = $this->qtiRunnerService->getItemData($context, $item->getHref());

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -29,6 +29,7 @@ use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoResultServer\models\classes\implementation\ResultServerService;
 use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 use stdClass;
+use taoResultServer_models_classes_OutcomeVariable;
 use taoResultServer_models_classes_ReadableResultStorage as ReadableResultStorage;
 use taoResultServer_models_classes_Variable as ResultVariable;
 
@@ -65,10 +66,17 @@ class SendCalculatedResultService
 
         $isFullyGraded = $this->checkIsFullyGraded($deliveryExecutionId, $outcomeVariables);
 
-        $timestamp = time();
-        $deliveryFinishMicrotime = $deliveryExecution->getFinishTime();
-        if ($deliveryFinishMicrotime !== null && $resultsUpdated === false) {
-            $timestamp = $this->secondsFromMicrotime($deliveryFinishMicrotime);
+        $microtime = null;
+        $timestamp = null;
+        $lastOutcome = end($outcomeVariables);
+        if (is_array($lastOutcome)) {
+            $lastOutcome = end($lastOutcome);
+        }
+        if ($lastOutcome->variable instanceof taoResultServer_models_classes_OutcomeVariable) {
+            $microtime = $lastOutcome->variable->getEpoch();
+        }
+        if ($microtime !== null) {
+            $timestamp = $this->secondsFromMicrotime($microtime);
         }
 
         $this->eventManager->trigger(

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -57,7 +57,7 @@ class SendCalculatedResultService
      * @throws \common_exception_NotFound
      * @throws InvalidServiceManagerException
      */
-    public function sendByDeliveryExecutionId(string $deliveryExecutionId, bool $resultsUpdated): array
+    public function sendByDeliveryExecutionId(string $deliveryExecutionId): array
     {
         $deliveryExecution = $this->deliveryExecutionService->getDeliveryExecution($deliveryExecutionId);
         $outcomeVariables = $this->getResultsStorage()->getDeliveryVariables($deliveryExecutionId);

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -41,9 +41,9 @@ class SendCalculatedResultService
     private DeliveredTestOutcomeDeclarationsService $deliveredTestOutcomeDeclarationsService;
 
     public function __construct(
-        ResultServerService                     $resultServerService,
-        EventManager                            $eventManager,
-        DeliveryExecutionService                $deliveryExecutionService,
+        ResultServerService $resultServerService,
+        EventManager $eventManager,
+        DeliveryExecutionService $deliveryExecutionService,
         DeliveredTestOutcomeDeclarationsService $qtiTestItemsService
     )
     {
@@ -168,7 +168,7 @@ class SendCalculatedResultService
     }
 
     private function isSubjectOutcomeVariableGraded(
-        array  $outcomeVariables,
+        array $outcomeVariables,
         string $outcomeDeclarationIdentifier,
         string $itemIdentifier
     ): bool

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -68,7 +68,8 @@ class SendCalculatedResultService
 
         $timestamp = $this->secondsFromMicrotime($deliveryExecution->getFinishTime());
         if ($isFullyGraded) {
-            $timestamp = $this->getLatestOutcomesTimestamp($outcomeVariables);
+            $outcomeTimestamp = $this->getLatestOutcomesTimestamp($outcomeVariables);
+            $timestamp = max($outcomeTimestamp, $timestamp);
         }
 
         $this->eventManager->trigger(

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -45,8 +45,7 @@ class SendCalculatedResultService
         EventManager $eventManager,
         DeliveryExecutionService $deliveryExecutionService,
         DeliveredTestOutcomeDeclarationsService $qtiTestItemsService
-    )
-    {
+    ) {
         $this->resultServerService = $resultServerService;
         $this->eventManager = $eventManager;
         $this->deliveryExecutionService = $deliveryExecutionService;
@@ -171,8 +170,7 @@ class SendCalculatedResultService
         array $outcomeVariables,
         string $outcomeDeclarationIdentifier,
         string $itemIdentifier
-    ): bool
-    {
+    ): bool {
         foreach ($outcomeVariables as $outcomeVariableArray) {
             $outcomeVariable = current($outcomeVariableArray);
             $outcomeItemIdentifier = $outcomeVariable->callIdItem;

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -66,7 +66,7 @@ class SendCalculatedResultService
 
         $isFullyGraded = $this->checkIsFullyGraded($deliveryExecutionId, $outcomeVariables);
 
-        $timestamp = $deliveryExecution->getFinishTime();
+        $timestamp = $this->secondsFromMicrotime($deliveryExecution->getFinishTime());
         if ($isFullyGraded) {
             $timestamp = $this->getLatestOutcomesTimestamp($outcomeVariables);
         }
@@ -77,7 +77,7 @@ class SendCalculatedResultService
                 $scoreTotal,
                 $scoreTotalMax,
                 $isFullyGraded,
-                (int)$timestamp
+                $timestamp
             )
         );
 

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -77,7 +77,7 @@ class SendCalculatedResultService
                 $scoreTotal,
                 $scoreTotalMax,
                 $isFullyGraded,
-                $timestamp
+                (int)$timestamp
             )
         );
 

--- a/models/Import/Task/ImportResultTask.php
+++ b/models/Import/Task/ImportResultTask.php
@@ -52,7 +52,6 @@ class ImportResultTask extends AbstractAction implements TaskAwareInterface, Jso
             if ($importResult->isSendAgs()) {
                 $this->getSendCalculatedResultService()->sendByDeliveryExecutionId(
                     $importResult->getDeliveryExecutionId(),
-                    $importResult->hasOutcomes()
                 );
             }
 

--- a/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
+++ b/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
@@ -309,7 +309,7 @@ class SendCalculatedResultServiceTest extends TestCase
             'identifier' => sprintf('OUTCOME_%d', $number),
             'cardinality' => 'single',
             'baseType' => 'float',
-            'epoch' => (string)time(),
+            'epoch' => '0.69485100 1690808122',
             'externallyGraded' => $isExternallyGraded,
         ];
         return OutcomeVariable::fromData($data);

--- a/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
+++ b/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
@@ -66,7 +66,11 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveryExecution')
             ->willReturn($this->deliveryExecutionMock);
 
-        $this->deliveryExecutionMock->expects($this->any())->method('getFinishTime')->willReturn('0.69485100 1690808122');
+        $this
+            ->deliveryExecutionMock
+            ->expects($this->any())
+            ->method('getFinishTime')
+            ->willReturn('0.69485100 1690808122');
 
         $this->sut = new SendCalculatedResultService(
             $this->resultServerServiceMock,

--- a/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
+++ b/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
@@ -66,6 +66,8 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveryExecution')
             ->willReturn($this->deliveryExecutionMock);
 
+        $this->deliveryExecutionMock->expects($this->any())->method('getFinishTime')->willReturn(1690808169);
+
         $this->sut = new SendCalculatedResultService(
             $this->resultServerServiceMock,
             $this->eventManagerMock,

--- a/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
+++ b/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
@@ -89,7 +89,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -112,7 +112,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -135,7 +135,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -158,7 +158,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -187,7 +187,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -217,7 +217,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -247,7 +247,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);
@@ -277,7 +277,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveredTestOutcomeDeclarations')
             ->willReturn($qtiTestItems);
 
-        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id', true);
+        $return = $this->sut->sendByDeliveryExecutionId('test_delivery_id');
 
         $this->assertIsArray($return);
         $this->assertArrayHasKey('isFullyGraded', $return);

--- a/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
+++ b/test/Unit/models/Import/Service/SendCalculatedResultServiceTest.php
@@ -66,7 +66,7 @@ class SendCalculatedResultServiceTest extends TestCase
             ->method('getDeliveryExecution')
             ->willReturn($this->deliveryExecutionMock);
 
-        $this->deliveryExecutionMock->expects($this->any())->method('getFinishTime')->willReturn(1690808169);
+        $this->deliveryExecutionMock->expects($this->any())->method('getFinishTime')->willReturn('0.69485100 1690808122');
 
         $this->sut = new SendCalculatedResultService(
             $this->resultServerServiceMock,


### PR DESCRIPTION
Ticket: 
- https://oat-sa.atlassian.net/browse/INF-230 
- https://oat-sa.atlassian.net/browse/INF-225
- https://oat-sa.atlassian.net/browse/INF-219
- https://oat-sa.atlassian.net/browse/INF-218

## What's Changed

- Return last outcome variable timestamp on AGS call, use all outcome declarations to check if test is fully graded

## How to test
- Create a test with item which has externally graded score, deliver and take a score.
- Call taoResultServer/api/DeliveryExecutionResults to update score and you will get last outcome variable timestamp
- Call again without updating the score and you will also receive last outcome variable timestamp
## Video

https://github.com/oat-sa/extension-tao-outcome/assets/118974926/b10ce132-9bf7-4259-b573-aa45a9420186

