### PR TITLE
bugfix: don't truncate milliseconds from timestamp

### DIFF
--- a/models/Events/DeliveryExecutionResultsRecalculated.php
+++ b/models/Events/DeliveryExecutionResultsRecalculated.php
@@ -32,14 +32,14 @@ class DeliveryExecutionResultsRecalculated implements Event
     private ?float $totalScore;
     private ?float $totalMaxScore;
     private bool $isFullyGraded;
-    private int $timestamp;
+    private ?string $timestamp;
 
     public function __construct(
         DeliveryExecutionInterface $deliveryExecution,
         ?float $totalScore,
         ?float $totalMaxScore,
         bool $isFullyGraded,
-        int $timestamp
+        ?string $timestamp
     ) {
         $this->deliveryExecution = $deliveryExecution;
         $this->totalScore = $totalScore;
@@ -73,7 +73,7 @@ class DeliveryExecutionResultsRecalculated implements Event
         return $this->isFullyGraded;
     }
 
-    public function getTimestamp(): int
+    public function getTimestamp(): ?string
     {
         return $this->timestamp;
     }

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -96,7 +96,9 @@ class ResultImporter
         float $updatedScoreTotal
     ): void {
         $scoreTotalVariable->setValue($updatedScoreTotal);
-        $scoreTotalVariable->setEpoch(microtime());
+        if ($scoreTotalVariable->getValue() != $updatedScoreTotal) {
+            $scoreTotalVariable->setEpoch(microtime());
+        }
 
         $resultStorage->replaceTestVariables(
             $deliveryExecutionUri,
@@ -183,7 +185,6 @@ class ResultImporter
                 $scoreTotal += $outcomeValue;
 
                 $variable->setValue($outcomeValue);
-                $variable->setEpoch(microtime());
                 $variable->setExternallyGraded(true);
 
                 $updateOutcomeVariables[$variableId] = $variable;

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -25,7 +25,6 @@ namespace oat\taoResultServer\models\Import\Service;
 use common_exception_Error;
 use core_kernel_persistence_Exception;
 use oat\generis\model\data\Ontology;
-use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
 use oat\taoResultServer\models\classes\ResultServerService;
@@ -37,7 +36,6 @@ use Throwable;
 
 class ResultImporter
 {
-    use LoggerAwareTrait;
     private Ontology $ontology;
     private ResultServerService $resultServerService;
 
@@ -99,7 +97,6 @@ class ResultImporter
     ): void {
         $scoreTotalVariable->setValue($updatedScoreTotal);
         $scoreTotalVariable->setEpoch(microtime());
-        $this->logInfo('updateTestVariables: Setting epoch '.print_r($scoreTotalVariable,true));
 
         $resultStorage->replaceTestVariables(
             $deliveryExecutionUri,
@@ -188,7 +185,7 @@ class ResultImporter
                 $variable->setValue($outcomeValue);
                 $variable->setEpoch(microtime());
                 $variable->setExternallyGraded(true);
-                $this->logInfo('updateItemOutcomeVariables: Setting epoch '.print_r($variable,true));
+
                 $updateOutcomeVariables[$variableId] = $variable;
             }
 

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -137,6 +137,7 @@ class ResultImporter
                 $itemUri = $responseVariable['itemUri'];
 
                 $variable->setCorrectResponse(boolval($responseValue['correctResponse']));
+                $variable->setEpoch(microtime());
 
                 $itemVariables[$variableId] = $variable;
             }

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -96,6 +96,7 @@ class ResultImporter
         float $updatedScoreTotal
     ): void {
         $scoreTotalVariable->setValue($updatedScoreTotal);
+        $scoreTotalVariable->setEpoch(microtime());
 
         $resultStorage->replaceTestVariables(
             $deliveryExecutionUri,
@@ -137,7 +138,6 @@ class ResultImporter
                 $itemUri = $responseVariable['itemUri'];
 
                 $variable->setCorrectResponse(boolval($responseValue['correctResponse']));
-                $variable->setEpoch(microtime());
 
                 $itemVariables[$variableId] = $variable;
             }

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -25,6 +25,7 @@ namespace oat\taoResultServer\models\Import\Service;
 use common_exception_Error;
 use core_kernel_persistence_Exception;
 use oat\generis\model\data\Ontology;
+use oat\oatbox\log\LoggerAwareTrait;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoOutcomeRds\model\AbstractRdsResultStorage;
 use oat\taoResultServer\models\classes\ResultServerService;
@@ -36,6 +37,7 @@ use Throwable;
 
 class ResultImporter
 {
+    use LoggerAwareTrait;
     private Ontology $ontology;
     private ResultServerService $resultServerService;
 
@@ -97,6 +99,7 @@ class ResultImporter
     ): void {
         $scoreTotalVariable->setValue($updatedScoreTotal);
         $scoreTotalVariable->setEpoch(microtime());
+        $this->logInfo('updateTestVariables: Setting epoch '.print_r($scoreTotalVariable,true));
 
         $resultStorage->replaceTestVariables(
             $deliveryExecutionUri,
@@ -185,7 +188,7 @@ class ResultImporter
                 $variable->setValue($outcomeValue);
                 $variable->setEpoch(microtime());
                 $variable->setExternallyGraded(true);
-
+                $this->logInfo('updateItemOutcomeVariables: Setting epoch '.print_r($variable,true));
                 $updateOutcomeVariables[$variableId] = $variable;
             }
 

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -182,6 +182,7 @@ class ResultImporter
                 $scoreTotal += $outcomeValue;
 
                 $variable->setValue($outcomeValue);
+                $variable->setEpoch(microtime());
                 $variable->setExternallyGraded(true);
 
                 $updateOutcomeVariables[$variableId] = $variable;

--- a/models/Import/Service/ResultImporter.php
+++ b/models/Import/Service/ResultImporter.php
@@ -95,10 +95,10 @@ class ResultImporter
         string $testUri,
         float $updatedScoreTotal
     ): void {
-        $scoreTotalVariable->setValue($updatedScoreTotal);
         if ($scoreTotalVariable->getValue() != $updatedScoreTotal) {
             $scoreTotalVariable->setEpoch(microtime());
         }
+        $scoreTotalVariable->setValue($updatedScoreTotal);
 
         $resultStorage->replaceTestVariables(
             $deliveryExecutionUri,

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -24,7 +24,6 @@ namespace oat\taoResultServer\models\Import\Service;
 
 use common_exception_Error;
 use oat\oatbox\event\EventManager;
-use oat\oatbox\log\LoggerAwareTrait;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoResultServer\models\classes\implementation\ResultServerService;

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -197,7 +197,7 @@ class SendCalculatedResultService
         return false;
     }
 
-    private function getLatestOutcomesTimestamp(array $outcomeVariables): ?int
+    private function getLatestOutcomesTimestamp(array $outcomeVariables): ?string
     {
         $microtimeList = array_map(function ($outcome) {
             $outcome = end($outcome);
@@ -206,11 +206,10 @@ class SendCalculatedResultService
             }
             return 0;
         }, $outcomeVariables);
-        $this->logInfo('getLatestOutcomesTimestamp:'.print_r($microtimeList,true));
-        $timestampList = array_map('self::formatTime', array_filter($microtimeList));
-        $this->logInfo('formatTime:'.print_r($timestampList,true));
 
-        return max($timestampList);
+        $latestOutcome = array_pop($microtimeList);
+
+        return $this->formatTime($latestOutcome);
     }
 
     /**

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -45,8 +45,7 @@ class SendCalculatedResultService
         EventManager $eventManager,
         DeliveryExecutionService $deliveryExecutionService,
         DeliveredTestOutcomeDeclarationsService $qtiTestItemsService
-    )
-    {
+    ) {
         $this->resultServerService = $resultServerService;
         $this->eventManager = $eventManager;
         $this->deliveryExecutionService = $deliveryExecutionService;
@@ -169,11 +168,10 @@ class SendCalculatedResultService
     }
 
     private function isSubjectOutcomeVariableGraded(
-        array  $outcomeVariables,
+        array $outcomeVariables,
         string $outcomeDeclarationIdentifier,
         string $itemIdentifier
-    ): bool
-    {
+    ): bool {
         foreach ($outcomeVariables as $outcomeVariableArray) {
             $outcomeVariable = current($outcomeVariableArray);
             $outcomeItemIdentifier = $outcomeVariable->callIdItem;

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -65,7 +65,7 @@ class SendCalculatedResultService
 
         $isFullyGraded = $this->checkIsFullyGraded($deliveryExecutionId, $outcomeVariables);
 
-        $timestamp = $deliveryExecution->getFinishTime();
+        $timestamp = $this->formatTime($deliveryExecution->getFinishTime());
 
         $this->eventManager->trigger(
             new DeliveryExecutionResultsRecalculated(
@@ -187,5 +187,30 @@ class SendCalculatedResultService
             }
         }
         return false;
+    }
+
+    /**
+     * Converts from microseconds seconds format to readable by Carbon seconds microseconds
+     * @example 0.47950700 1700135696 to 1700135696.47950700
+     * @param string|null $time
+     * @return string|null
+     */
+    private function formatTime(?string $time): ?string
+    {
+        if ($time === null) {
+            return null;
+        }
+
+        // Split the string into microseconds and seconds
+        list($microseconds, $seconds) = explode(' ', $time);
+
+        // Show only the numbers after the dot without the integral part
+        list(, $decimalPart) = explode('.', sprintf('%0.8f', $microseconds));
+
+
+        $dateTime = \DateTimeImmutable::createFromFormat('U', $seconds);
+
+        // Combine seconds and microseconds
+        return  $dateTime->format('U') . '.' . $decimalPart;
     }
 }

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -36,8 +36,6 @@ use taoResultServer_models_classes_OutcomeVariable as OutcomeVariable;
 
 class SendCalculatedResultService
 {
-    use LoggerAwareTrait;
-
     private ResultServerService $resultServerService;
     private EventManager $eventManager;
     private DeliveryExecutionService $deliveryExecutionService;

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -71,8 +71,7 @@ class SendCalculatedResultService
         $timestamp = $this->formatTime($deliveryExecution->getFinishTime());
 
         if ($isFullyGraded) {
-            $outcomeTimestamp = $this->getLatestOutcomesTimestamp($outcomeVariables);
-            $timestamp = max($outcomeTimestamp, $timestamp);
+            $timestamp = $this->getLatestOutcomesTimestamp($outcomeVariables);
         }
 
         $this->eventManager->trigger(

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -226,11 +226,12 @@ class SendCalculatedResultService
 
         // Show only the numbers after the dot without the integral part
         list(, $decimalPart) = explode('.', sprintf('%0.6f', $microseconds));
+        //To preserve time zone we are not using createFromFormat()
+        $date = new \DateTime();
+        $date->setTimestamp((int)$seconds);
+        $date->modify('+ ' . $decimalPart . ' microseconds');
 
-        $dateTimeWithZone =  \DateTime::createFromFormat('U.u', $seconds.'.'.$decimalPart);
-        $dateTimeWithZone->setTimeZone(new DateTimeZone(TIME_ZONE));
-
-        return $dateTimeWithZone->format(DateTimeInterface::RFC3339_EXTENDED);
+        return $date->format(DateTimeInterface::RFC3339_EXTENDED);
     }
 
     private function sortMicrotimeList(array $microtimeList): array

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -203,7 +203,7 @@ class SendCalculatedResultService
             }
             return 0;
         }, $outcomeVariables);
-        $sortedMicrotime = $this->sortMicrotimeList($microtimeList);
+        $sortedMicrotime = $this->sortMicrotimeList(array_filter($microtimeList));
         $latestOutcome = array_pop($sortedMicrotime);
 
         return $this->formatTime($latestOutcome);

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -205,7 +205,7 @@ class SendCalculatedResultService
             }
             return 0;
         }, $outcomeVariables);
-
+        $this->logInfo('getLatestOutcomesTimestamp:$microtimeList'.print_r($microtimeList,true));
         $latestOutcome = array_pop($microtimeList);
 
         return $this->formatTime($latestOutcome);

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -32,6 +32,7 @@ use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 use stdClass;
 use taoResultServer_models_classes_ReadableResultStorage as ReadableResultStorage;
 use taoResultServer_models_classes_Variable as ResultVariable;
+use taoResultServer_models_classes_OutcomeVariable as OutcomeVariable;
 
 class SendCalculatedResultService
 {
@@ -183,7 +184,7 @@ class SendCalculatedResultService
                 continue;
             }
 
-            if (!$outcomeVariable->variable instanceof ResultVariable) {
+            if (!$outcomeVariable->variable instanceof OutcomeVariable) {
                 continue;
             }
             $variable = $outcomeVariable->variable;
@@ -207,10 +208,9 @@ class SendCalculatedResultService
             }
             return 0;
         }, $outcomeVariables);
-        $this->logInfo('getLatestOutcomesTimestamp:$microtimeList' . print_r($microtimeList, true));
         $sortedMicrotime = $this->sortMicrotimeList($microtimeList);
-        $this->logInfo('$sortedMicrotime:'. print_r($sortedMicrotime, true));
         $latestOutcome = array_pop($sortedMicrotime);
+
         return $this->formatTime($latestOutcome);
     }
 

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -184,7 +184,7 @@ class SendCalculatedResultService
                 continue;
             }
 
-            if (!$outcomeVariable->variable instanceof OutcomeVariable) {
+            if (!$outcomeVariable->variable instanceof ResultVariable) {
                 continue;
             }
             $variable = $outcomeVariable->variable;
@@ -203,7 +203,7 @@ class SendCalculatedResultService
     {
         $microtimeList = array_map(function ($outcome) {
             $outcome = end($outcome);
-            if ($outcome->variable instanceof ResultVariable) {
+            if ($outcome->variable instanceof OutcomeVariable) {
                 return $outcome->variable->getEpoch();
             }
             return 0;

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -30,7 +30,6 @@ use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoResultServer\models\classes\implementation\ResultServerService;
 use oat\taoResultServer\models\Events\DeliveryExecutionResultsRecalculated;
 use stdClass;
-use taoResultServer_models_classes_OutcomeVariable;
 use taoResultServer_models_classes_ReadableResultStorage as ReadableResultStorage;
 use taoResultServer_models_classes_Variable as ResultVariable;
 
@@ -200,7 +199,7 @@ class SendCalculatedResultService
     {
         $microtimeList = array_map(function ($outcome) {
             $outcome = end($outcome);
-            if ($outcome->variable instanceof taoResultServer_models_classes_OutcomeVariable) {
+            if ($outcome->variable instanceof ResultVariable) {
                 return $outcome->variable->getEpoch();
             }
             return 0;

--- a/models/Import/Task/ImportResultTask.php
+++ b/models/Import/Task/ImportResultTask.php
@@ -65,8 +65,9 @@ class ImportResultTask extends AbstractAction implements TaskAwareInterface, Jso
             return Report::createSuccess($message);
         } catch (Throwable $exception) {
             $message = sprintf(
-                '[DeliveryExecutionResults] Error [%s] importing results [%s]',
+                '[DeliveryExecutionResults] Error [%s] Stacktrace [%s] importing results [%s]',
                 $exception->getMessage(),
+                $exception->getTraceAsString(),
                 isset($importResult) ? var_export($importResult->jsonSerialize(), true) : ''
             );
 

--- a/models/Import/Task/ImportResultTask.php
+++ b/models/Import/Task/ImportResultTask.php
@@ -65,9 +65,8 @@ class ImportResultTask extends AbstractAction implements TaskAwareInterface, Jso
             return Report::createSuccess($message);
         } catch (Throwable $exception) {
             $message = sprintf(
-                '[DeliveryExecutionResults] Error [%s] Stacktrace [%s] importing results [%s]',
+                '[DeliveryExecutionResults] Error [%s] importing results [%s]',
                 $exception->getMessage(),
-                $exception->getTraceAsString(),
                 isset($importResult) ? var_export($importResult->jsonSerialize(), true) : ''
             );
 

--- a/test/Unit/models/Import/Service/ResultImporterTest.php
+++ b/test/Unit/models/Import/Service/ResultImporterTest.php
@@ -180,9 +180,13 @@ class ResultImporterTest extends TestCase
                 'executionId',
                 'testUri',
                 'executionId',
-                [
-                    777 => $this->createTestVariable(4, 'SCORE_TOTAL'),
-                ]
+                $this->callback(function($array) {
+                    $variable = array_pop($array);
+                    return $variable->getIdentifier() === 'SCORE_TOTAL'
+                        && $variable->getCardinality() === 'single'
+                        && $variable->getBaseType() === 'float'
+                        && $variable->getExternallyGraded() === false;
+                })
             );
 
         $this->resultStorage

--- a/test/Unit/models/Import/Service/ResultImporterTest.php
+++ b/test/Unit/models/Import/Service/ResultImporterTest.php
@@ -180,7 +180,7 @@ class ResultImporterTest extends TestCase
                 'executionId',
                 'testUri',
                 'executionId',
-                $this->callback(function($array) {
+                $this->callback(function ($array) {
                     $variable = array_pop($array);
                     return $variable->getIdentifier() === 'SCORE_TOTAL'
                         && $variable->getCardinality() === 'single'

--- a/test/Unit/models/Import/Service/ResultImporterTest.php
+++ b/test/Unit/models/Import/Service/ResultImporterTest.php
@@ -515,6 +515,7 @@ class ResultImporterTest extends TestCase
         $variable->setIdentifier($identifier);
         $variable->setCardinality('single');
         $variable->setBaseType('float');
+        $variable->setEpoch(microtime());
 
         return $variable;
     }


### PR DESCRIPTION
Ticket: 
https://oat-sa.atlassian.net/browse/INF-235
https://oat-sa.atlassian.net/browse/INF-236
https://oat-sa.atlassian.net/browse/INF-237
https://oat-sa.atlassian.net/browse/INF-238
https://oat-sa.atlassian.net/browse/INF-239

## What's Changed

- Fixes for truncated timestamp in AGS items 


## Dependencies PRs

- https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/363
- https://github.com/oat-sa/tao-core/pull/3928