### PR TITLE
Bugfix/inf 248 not send ags with outcome processing set to none

### DIFF
--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -67,7 +67,12 @@ class SendCalculatedResultService
 
         $isFullyGraded = $this->checkIsFullyGraded($deliveryExecutionId, $outcomeVariables);
 
-        $timestamp = DateHelper::formatMicrotime($this->getScoreTotalTimestamp($outcomeVariables));
+        $microtime = $deliveryExecution->getFinishTime();
+        $scoreTotalMicrotime = $this->getScoreTotalTimestamp($outcomeVariables);
+        if ($scoreTotalMicrotime != null) {
+            $microtime = $scoreTotalMicrotime;
+        }
+        $timestamp = DateHelper::formatMicrotime($microtime);
 
         $this->eventManager->trigger(
             new DeliveryExecutionResultsRecalculated(

--- a/models/Import/Service/SendCalculatedResultService.php
+++ b/models/Import/Service/SendCalculatedResultService.php
@@ -69,7 +69,7 @@ class SendCalculatedResultService
 
         $microtime = $deliveryExecution->getFinishTime();
         $scoreTotalMicrotime = $this->getScoreTotalTimestamp($outcomeVariables);
-        if ($scoreTotalMicrotime != null) {
+        if ($scoreTotalMicrotime !== null) {
             $microtime = $scoreTotalMicrotime;
         }
         $timestamp = DateHelper::formatMicrotime($microtime);


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-248

## What's Changed

Moving the event to the end of Delivery Execution gives us access to Outcomes and DE Finish time at the same time. We need both of these values to cover the case when a query is sent via the AGS API without changing the result and when the test is set with Outcomes is set to none

## Dependencies PRs

- https://github.com/oat-sa/extension-tao-testqti/pull/2432
- https://github.com/oat-sa/extension-tao-ltideliveryprovider/pull/371