### PR TITLE
fix: parse record-typed candidate response values when reading the remote results.xml

### DIFF
--- a/test/Unit/models/Mapper/ResultMapperTest.php
+++ b/test/Unit/models/Mapper/ResultMapperTest.php
@@ -15,8 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2019-2024 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoResultServer\test\Unit\models\Mapper;
@@ -124,7 +123,7 @@ class ResultMapperTest extends TestCase
     public function testGetItemVariables()
     {
         $variablesByItemResult = $this->load()->getItemVariables();
-        $this->assertCount(3, $variablesByItemResult);
+        $this->assertCount(4, $variablesByItemResult);
 
         $this->assertArrayHasKey('fixture-identifier-itemResult1', $variablesByItemResult);
         $this->assertArrayHasKey('fixture-identifier-itemResult2', $variablesByItemResult);
@@ -186,6 +185,54 @@ class ResultMapperTest extends TestCase
         $this->assertEquals('fixture-value20', $variable4->getCorrectResponse());
         $this->assertEquals('single', $variable4->getCardinality());
         $this->assertEquals('identifier', $variable4->getBaseType());
+
+        /** @var taoResultServer_models_classes_ResponseVariable $variable5 */
+        $variable5 = $variablesByItemResult['fixture-identifier-itemResult4'][0];
+        $this->assertInstanceOf(\taoResultServer_models_classes_ResponseVariable::class, $variable5);
+        $this->assertEquals('fixture-identifier6', $variable5->getIdentifier());
+        $this->assertEquals(
+            json_encode(
+                [
+                    'record' => [
+                        [
+                            'name' => 'correct',
+                            'base' => [
+                                'integer' => 1
+                            ]
+                        ],
+                        [
+                            'name' => 'candidateResponse',
+                            'base' => [
+                                'string' => ''
+                            ]
+                        ],
+                        [
+                            'name' => 'score',
+                            'base' => [
+                                'integer' => 1
+                            ]
+                        ],
+                        [
+                            'name' => 'maxscore',
+                            'base' => [
+                                'integer' => 1
+                            ]
+                        ],
+                        [
+                            'name' => 'applet',
+                            'base' => [
+                                'string' => 'payload'
+                            ]
+                        ]
+                    ]
+                ]
+            ),
+            $variable5->getCandidateResponse()
+        );
+        $this->assertEquals('record', $variable5->getCardinality());
+        $this->assertNull($variable5->getBaseType());
+        $epochDateTime = (new DateTime())->setTimestamp(explode(' ', $variable5->getEpoch())[1]);
+        $this->assertSame('2018-06-27T09:45:45', $epochDateTime->format('Y-m-d\TH:i:s'));
     }
 
     public function testGetItemVariablesWithTemplateVariables()

--- a/test/resources/result/simple-assessment-result.xml
+++ b/test/resources/result/simple-assessment-result.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This program is free software; you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License
+  ~ as published by the Free Software Foundation; under version 2
+  ~ of the License (non-upgradable).
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+  ~
+  ~ Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+  -->
+
 <assessmentResult xmlns="http://www.imsglobal.org/xsd/imsqti_result_v2p1"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_result_v2p1  http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_result_v2p1.xsd">
@@ -59,5 +77,16 @@
         <outcomeVariable cardinality="single" identifier="fixture-identifier6" baseType="string" view="candidate" interpretation="fixture-interpretation" longInterpretation="http://fixture-interpretation" normalMinimum="4" normalMaximum="6" masteryValue="5">
             <value>fixture-value19</value>
         </outcomeVariable>
+    </itemResult>
+    <itemResult identifier="fixture-identifier-itemResult4" datestamp="2018-06-27T09:45:45.529" sessionStatus="final" sequenceIndex="2">
+        <responseVariable cardinality="record" identifier="fixture-identifier6">
+            <candidateResponse>
+                <value fieldIdentifier="correct" baseType="integer">1</value>
+                <value fieldIdentifier="candidateResponse" baseType="string"/>
+                <value fieldIdentifier="score" baseType="integer">1</value>
+                <value fieldIdentifier="maxscore" baseType="integer">1</value>
+                <value fieldIdentifier="applet" baseType="string">payload</value>
+            </candidateResponse>
+        </responseVariable>
     </itemResult>
 </assessmentResult>


### PR DESCRIPTION
# [TR-5267](https://oat-sa.atlassian.net/browse/TR-5267)

This PR parses `record`-typed values and records them as JSON when reading remote results.xml

|Before|After|
|-|-|
|<img width="1305" alt="image" src="https://github.com/user-attachments/assets/59893fd5-a6bc-4550-9ae3-2966a205534d">|<img width="1305" alt="image" src="https://github.com/user-attachments/assets/7fde00fa-e4e4-46aa-bed3-2a94de49d187">|

[TR-5267]: https://oat-sa.atlassian.net/browse/TR-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ